### PR TITLE
Credit Card Regex Classes

### DIFF
--- a/src/RegexCollection/AmericanExpressCreditCard.php
+++ b/src/RegexCollection/AmericanExpressCreditCard.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace YorCreative\Scrubber\RegexCollection;
+
+use YorCreative\Scrubber\RegexCollectionInterface;
+
+class AmericanExpressCreditCard implements RegexCollectionInterface
+{
+    public function getPattern(): string
+    {
+        return '((4\d{3})(34\d{1})|(37\d{1}))-?\s?\d{4}-?\s?\d{4}-?\s?\d{4}|3[4,7][\d\s-]{15}$';
+    }
+
+    public function getTestableString(): string
+    {
+        return '378282246310005';
+    }
+}

--- a/src/RegexCollection/DiscoverCreditCard.php
+++ b/src/RegexCollection/DiscoverCreditCard.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace YorCreative\Scrubber\RegexCollection;
+
+use YorCreative\Scrubber\RegexCollectionInterface;
+
+class DiscoverCreditCard implements RegexCollectionInterface
+{
+    public function getPattern(): string
+    {
+        return '((6011))-?\s?\d{4}-?\s?\d{4}-?\s?\d{4}|3[4,7][\d\s-]{15}$';
+    }
+
+    public function getTestableString(): string
+    {
+        return '6011111111111117';
+    }
+}

--- a/src/RegexCollection/MasterCardCreditCard.php
+++ b/src/RegexCollection/MasterCardCreditCard.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace YorCreative\Scrubber\RegexCollection;
+
+use YorCreative\Scrubber\RegexCollectionInterface;
+
+class MasterCardCreditCard implements RegexCollectionInterface
+{
+    public function getPattern(): string
+    {
+        return '((5[1-5]\d{2}))-?\s?\d{4}-?\s?\d{4}-?\s?\d{4}|3[4,7][\d\s-]{15}$';
+    }
+
+    public function getTestableString(): string
+    {
+        return '5555555555554444';
+    }
+}

--- a/src/RegexCollection/VisaCreditCard.php
+++ b/src/RegexCollection/VisaCreditCard.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace YorCreative\Scrubber\RegexCollection;
+
+use YorCreative\Scrubber\RegexCollectionInterface;
+
+class VisaCreditCard implements RegexCollectionInterface
+{
+    public function getPattern(): string
+    {
+        return '((4\d{3}))-?\s?\d{4}-?\s?\d{4}-?\s?\d{4}|3[4,7][\d\s-]{15}$';
+    }
+
+    public function getTestableString(): string
+    {
+        return '4242424242424242';
+    }
+}


### PR DESCRIPTION
Added ability to detect and scrub credit numbers for:

- Master Card
- Visa
- Discover
- American Express