### PR TITLE
Patched Stub & Extended Regex Loader

### DIFF
--- a/src/Commands/Stubs/RegexCollectionClass.stub
+++ b/src/Commands/Stubs/RegexCollectionClass.stub
@@ -21,4 +21,9 @@ class DummyClass implements RegexCollectionInterface
          * @note return a string that can be used to verify the regex pattern provided.
          */
     }
+
+    public function isSecret(): bool
+    {
+        return false;
+    }
 }

--- a/src/Strategies/RegexLoader/Loaders/ExtendedRegex.php
+++ b/src/Strategies/RegexLoader/Loaders/ExtendedRegex.php
@@ -9,6 +9,9 @@ use YorCreative\Scrubber\Strategies\RegexLoader\LoaderInterface;
 
 class ExtendedRegex implements LoaderInterface
 {
+    /**
+     * @var string
+     */
     private string $path;
 
     public function __construct()
@@ -30,7 +33,7 @@ class ExtendedRegex implements LoaderInterface
     public function load(Collection &$regexCollection): void
     {
         foreach (File::files($this->path) as $regexClass) {
-            $regex = (new ('YorCreative\Scrubber\RegexCollection\\'.$regexClass)());
+            $regex = (new ('App\\Scrubber\\RegexCollection\\'.$regexClass->getFilenameWithoutExtension())());
 
             $regexCollection = $regexCollection->merge([
                 Str::snake($regexClass->getFilenameWithoutExtension()) => $regex,


### PR DESCRIPTION
- Added isSecret() method to make:regex-class command stub.
- Updated path when instantiating custom regex classes and loading into regex collection.