### PR TITLE
Tap Loader Strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ return [
         ],
     ],
     'regex_loader' => ['*'] // Opt-in to specific regex classes or include all with * wildcard.
+    'tap_channels' => ['*'] // Opt-in to tap specific log channels or include all with * wildcard.
 ];
 ```
 
@@ -100,6 +101,21 @@ Scrubber::processMessage([
 
 Scrubber::processMessage('<insert jwt token here>');
 // **redacted**
+```
+## Log Channel Opt-in
+
+This package provides you the ability to define through the configuration file what channels you want to scrub
+specifically. By default, this package ships with a wildcard value and opts in to scrub all the log channels
+in your application. 
+
+### Defining Log Channel Opt-in
+To opt in to one or more channels, list the channel(s) name into the `tap_channels` array in the config.
+
+```php
+'tap_channels' => [
+    'single',
+    'papertrail'
+]
 ```
 
 ## Regex Class Opt-in

--- a/config/scrubber.php
+++ b/config/scrubber.php
@@ -17,4 +17,5 @@ return [
         ],
     ],
     'regex_loader' => ['*'],
+    'tap_channels' => ['*']
 ];

--- a/src/Services/ScrubberService.php
+++ b/src/Services/ScrubberService.php
@@ -2,6 +2,7 @@
 
 namespace YorCreative\Scrubber\Services;
 
+use Carbon\Carbon;
 use YorCreative\Scrubber\Interfaces\RegexCollectionInterface;
 use YorCreative\Scrubber\Repositories\RegexRepository;
 use YorCreative\Scrubber\SecretManager\Secret;
@@ -28,10 +29,15 @@ class ScrubberService
     public static function decodeRecord($scrubbedContent): mixed
     {
         if (! is_array($scrubbedContent)) {
-            return json_decode($scrubbedContent, true);
-        } else {
-            return $scrubbedContent;
+            $scrubbedContent = json_decode($scrubbedContent, true);
         }
+
+        // set datetime back to  DateTimeInterface for papertrail specifically.
+        if(isset($scrubbedContent['datetime'])) {
+            $scrubbedContent['datetime'] = Carbon::parse($scrubbedContent['datetime']);
+        }
+
+        return $scrubbedContent;
     }
 
     /**

--- a/src/Strategies/TapLoader/Loaders/DefaultChannels.php
+++ b/src/Strategies/TapLoader/Loaders/DefaultChannels.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace YorCreative\Scrubber\Strategies\TapLoader\Loaders;
+
+use Illuminate\Config\Repository;
+use YorCreative\Scrubber\Handlers\ScrubberTap;
+
+class DefaultChannels extends WildCardChannel
+{
+    /**
+     * @return bool
+     */
+    public final function canLoad(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @param Repository $config
+     */
+    public function load(Repository &$config): void
+    {
+        $channels = $config->get('logging.channels');
+
+        foreach($channels as $key => $channel) {
+            $config->set("logging.channels.$key.tap", [
+                ScrubberTap::class,
+            ]);
+        }
+    }
+}

--- a/src/Strategies/TapLoader/Loaders/MultipleChannel.php
+++ b/src/Strategies/TapLoader/Loaders/MultipleChannel.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace YorCreative\Scrubber\Strategies\TapLoader\Loaders;
+
+use Illuminate\Config\Repository;
+use Illuminate\Support\Facades\Config;
+use YorCreative\Scrubber\Handlers\ScrubberTap;
+use YorCreative\Scrubber\Strategies\TapLoader\TapLoaderInterface;
+
+class MultipleChannel implements TapLoaderInterface
+{
+    /**
+     * @return bool
+     */
+    public function canLoad(): bool
+    {
+        $channels = Config::get('scrubber.tap_channels');
+        if(!$channels) return false;
+
+        return !in_array('*', Config::get('scrubber.tap_channels'))
+            && count(Config::get('scrubber.tap_channels')) > 1;
+    }
+
+    /**
+     * @param Repository $config
+     */
+    public function load(Repository &$config): void
+    {
+        foreach(Config::get('scrubber.tap_channels') as $channel) {
+            $config->set("logging.channels.$channel.tap", [
+                ScrubberTap::class,
+            ]);
+        }
+    }
+}

--- a/src/Strategies/TapLoader/Loaders/SpecificChannel.php
+++ b/src/Strategies/TapLoader/Loaders/SpecificChannel.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace YorCreative\Scrubber\Strategies\TapLoader\Loaders;
+
+use Illuminate\Config\Repository;
+use Illuminate\Support\Facades\Config;
+use YorCreative\Scrubber\Handlers\ScrubberTap;
+use YorCreative\Scrubber\Strategies\TapLoader\TapLoaderInterface;
+
+class SpecificChannel implements TapLoaderInterface
+{
+    /**
+     * @return bool
+     */
+    public function canLoad(): bool
+    {
+        $channels = Config::get('scrubber.tap_channels');
+        if(!$channels) return false;
+
+        return !in_array('*', Config::get('scrubber.tap_channels'))
+            && count(Config::get('scrubber.tap_channels')) < 2;
+    }
+
+    /**
+     * @param Repository $config
+     */
+    public function load(Repository &$config): void
+    {
+        $key = Config::get('scrubber.tap_channels')[0];
+
+        $config->set("logging.channels.$key.tap", [
+            ScrubberTap::class,
+        ]);
+    }
+}

--- a/src/Strategies/TapLoader/Loaders/WildCardChannel.php
+++ b/src/Strategies/TapLoader/Loaders/WildCardChannel.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace YorCreative\Scrubber\Strategies\TapLoader\Loaders;
+
+use Illuminate\Config\Repository;
+use Illuminate\Support\Facades\Config;
+use YorCreative\Scrubber\Handlers\ScrubberTap;
+use YorCreative\Scrubber\Strategies\TapLoader\TapLoaderInterface;
+
+class WildCardChannel implements TapLoaderInterface
+{
+    /**
+     * @return bool
+     */
+    public function canLoad(): bool
+    {
+        $channels = Config::get('scrubber.tap_channels');
+        if(!$channels) return false;
+
+        return in_array('*', Config::get('scrubber.tap_channels'));
+    }
+
+    /**
+     * @param Repository $config
+     */
+    public function load(Repository &$config): void
+    {
+        $channels = $config->get('logging.channels');
+
+        foreach($channels as $key => $channel) {
+            $config->set("logging.channels.$key.tap", [
+                ScrubberTap::class,
+            ]);
+        }
+    }
+}

--- a/src/Strategies/TapLoader/TapLoaderInterface.php
+++ b/src/Strategies/TapLoader/TapLoaderInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace YorCreative\Scrubber\Strategies\TapLoader;
+
+use Illuminate\Config\Repository;
+
+interface TapLoaderInterface
+{
+    public function canLoad(): bool;
+
+    public function load(Repository &$config): void;
+}

--- a/src/Strategies/TapLoader/TapLoaderStrategy.php
+++ b/src/Strategies/TapLoader/TapLoaderStrategy.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace YorCreative\Scrubber\Strategies\TapLoader;
+
+use Illuminate\Config\Repository;
+use Illuminate\Support\Collection;
+
+class TapLoaderStrategy
+{
+    /**
+     * @var Collection
+     */
+    public Collection $availableLoaders;
+
+    public function __construct()
+    {
+        $this->availableLoaders = new Collection();
+    }
+
+    /**
+     * @param  TapLoaderInterface  $loader
+     */
+    public function setLoader(TapLoaderInterface $loader): void
+    {
+        $this->availableLoaders->push($loader);
+    }
+
+    /**
+     * @param Repository $config
+     */
+    public function load(Repository &$config): void
+    {
+        $this->availableLoaders->each(function ($loader) use (&$config) {
+            if ($loader->canLoad()) {
+                $loader->load($config);
+            }
+        });
+    }
+}

--- a/tests/Unit/Strategies/RegexLoaderStrategyTest.php
+++ b/tests/Unit/Strategies/RegexLoaderStrategyTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace YorCreative\Scrubber\Test\Unit\Services;
+namespace YorCreative\Scrubber\Test\Unit\Strategies;
 
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Config;

--- a/tests/Unit/Strategies/TapLoaderStrategyTest.php
+++ b/tests/Unit/Strategies/TapLoaderStrategyTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace YorCreative\Scrubber\Test\Unit\Strategies;
+
+use Illuminate\Support\Facades\Config;
+use YorCreative\Scrubber\Strategies\TapLoader\TapLoaderStrategy;
+use YorCreative\Scrubber\Tests\TestCase;
+
+class TapLoaderStrategyTest extends TestCase
+{
+    /**
+     * @test
+     * @group Strategy
+     * @group Unit
+     */
+    public function it_can_load_wildcard_channels_and_tap()
+    {
+        $config = app()->make('config');
+
+        Config::set('scrubber.tap_channels', ['*']);
+
+        app(TapLoaderStrategy::class)->load($config);
+
+        foreach($config->get('logging.channels') as $channel) {
+            $this->assertArrayHasKey('tap', $channel);
+        }
+    }
+
+    /**
+     * @test
+     * @group Strategy
+     * @group Unit
+     */
+    public function it_can_load_specific_channel_and_tap()
+    {
+        $config = app()->make('config');
+
+        Config::set('scrubber.tap_channels', ['single']);
+
+        app(TapLoaderStrategy::class)->load($config);
+
+        $this->assertArrayHasKey('tap', $config->get('logging.channels.single'));
+    }
+
+    /**
+     * @test
+     * @group Strategy
+     * @group Unit
+     */
+    public function it_can_load_multiple_channels_and_tap()
+    {
+        $config = app()->make('config');
+
+        Config::set('scrubber.tap_channels', ['single', 'papertrail']);
+
+        app(TapLoaderStrategy::class)->load($config);
+
+        $this->assertArrayHasKey('tap', $config->get('logging.channels.single'));
+        $this->assertArrayHasKey('tap', $config->get('logging.channels.papertrail'));
+    }
+
+    /**
+     * @test
+     * @group Strategy
+     * @group Unit
+     */
+    public function it_can_default_to_load_wildcard_channels_and_tap()
+    {
+        $config = app()->make('config');
+
+        Config::set('scrubber.tap_channels', null);
+
+
+        app(TapLoaderStrategy::class)->load($config);
+
+        foreach($config->get('logging.channels') as $channel) {
+            $this->assertArrayHasKey('tap', $channel);
+        }
+    }
+}


### PR DESCRIPTION
- Added strategy to load channel taps.
- Added 3 loaders: wildcard, specific and multiple channel tap loaders.
- Added test coverage for tap loader strategy.
- Added "tap_channels" to config with wildcard default.
- Added log channel opt-in information to README