### PR TITLE
TapLoaderStrategy :construction: :bug: :hammer:  :construction:

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,5 +251,6 @@ composer test
 ## Credits
 
 - [Yorda](https://github.com/yordadev)
+- [Whizboy-Arnold](https://github.com/Whizboy-Arnold)
 - [All Contributors](../../contributors)
 

--- a/src/Clients/BaseClient.php
+++ b/src/Clients/BaseClient.php
@@ -15,7 +15,6 @@ abstract class BaseClient
     }
 
     /**
-     * @param  string  $path
      * @return mixed
      *
      * @throws GuzzleException

--- a/src/Repositories/RegexRepository.php
+++ b/src/Repositories/RegexRepository.php
@@ -3,37 +3,19 @@
 namespace YorCreative\Scrubber\Repositories;
 
 use Illuminate\Support\Collection;
-use YorCreative\Scrubber\Strategies\RegexLoader\RegexLoaderStrategy;
 
 class RegexRepository
 {
-    public Collection $regexCollection;
-
-    public function __construct()
-    {
-        $this->regexCollection = new Collection();
-        $this->loadRegexClasses();
+    public function __construct(
+        protected Collection $regexCollection
+    ) {
     }
 
-    protected function loadRegexClasses(): void
-    {
-        app(RegexLoaderStrategy::class)->load($this->regexCollection);
-    }
-
-    /**
-     * @param  string  $regex
-     * @param  string  $content
-     * @param  int  $hits
-     * @return string
-     */
     public static function checkAndSanitize(string $regex, string $content, int &$hits = 0): string
     {
         return preg_replace("~$regex~i", config('scrubber.redaction'), $content, -1, $hits);
     }
 
-    /**
-     * @return Collection
-     */
     public function getRegexCollection(): Collection
     {
         return $this->regexCollection;

--- a/src/Scrubber.php
+++ b/src/Scrubber.php
@@ -6,10 +6,6 @@ use YorCreative\Scrubber\Services\ScrubberService;
 
 class Scrubber
 {
-    /**
-     * @param $content
-     * @return array|string
-     */
     public static function processMessage($content): array|string
     {
         return is_array($content)
@@ -17,10 +13,6 @@ class Scrubber
             : self::processString($content);
     }
 
-    /**
-     * @param  array  $content
-     * @return array
-     */
     private static function processArray(array $content): array
     {
         $jsonContent = ScrubberService::encodeRecord($content);
@@ -34,10 +26,6 @@ class Scrubber
         return ScrubberService::decodeRecord($jsonContent);
     }
 
-    /**
-     * @param  array  $content
-     * @return array
-     */
     private static function processArrayRecursively(array $content): array
     {
         foreach ($content as $key => $value) {
@@ -55,10 +43,6 @@ class Scrubber
         return $content;
     }
 
-    /**
-     * @param $content
-     * @return string
-     */
     private static function processString($content): string
     {
         ScrubberService::autoSanitize($content);

--- a/src/ScrubberServiceProvider.php
+++ b/src/ScrubberServiceProvider.php
@@ -24,6 +24,7 @@ class ScrubberServiceProvider extends ServiceProvider
     public function register()
     {
         $this->mergeConfigFrom(dirname(__DIR__, 1).'/config/scrubber.php', 'scrubber');
+
         $this->commands(
             'YorCreative\\Scrubber\\Commands\\MakeRegexClass'
         );
@@ -70,10 +71,10 @@ class ScrubberServiceProvider extends ServiceProvider
             return $tapLoaderStrategy;
         });
 
-        $this->app->singleton(RegexRepository::class, function () {
-            $regexRepository = new RegexRepository();
+        $this->app->make(TapLoaderStrategy::class)->load($this->app->make('config'));
 
-            return $regexRepository;
+        $this->app->singleton(RegexRepository::class, function ($app) {
+            return new RegexRepository($app->make(RegexLoaderStrategy::class)->load());
         });
     }
 }

--- a/src/SecretManager/Providers/Gitlab.php
+++ b/src/SecretManager/Providers/Gitlab.php
@@ -19,9 +19,6 @@ class Gitlab implements SecretProviderInterface
     public static string $VARIABLE = '/api/v4/projects/{id}/variables/{key}';
 
     /**
-     * @param  string  $key
-     * @return Secret
-     *
      * @throws GuzzleException
      */
     public static function getSpecificSecret(string $key): Secret
@@ -42,9 +39,6 @@ class Gitlab implements SecretProviderInterface
     }
 
     /**
-     * @param  string  $path
-     * @return array
-     *
      * @throws SecretProviderException
      * @throws ContainerExceptionInterface
      * @throws NotFoundExceptionInterface
@@ -59,8 +53,6 @@ class Gitlab implements SecretProviderInterface
     }
 
     /**
-     * @return Collection
-     *
      * @throws GuzzleException
      */
     public static function getAllSecrets(): Collection

--- a/src/SecretManager/Secret.php
+++ b/src/SecretManager/Secret.php
@@ -17,9 +17,6 @@ class Secret
         $this->variable = self::getEncrypter()->encryptString($variable);
     }
 
-    /**
-     * @return Encrypter
-     */
     private static function getEncrypter(): Encrypter
     {
         return new Encrypter(
@@ -28,26 +25,16 @@ class Secret
         );
     }
 
-    /**
-     * @param  string  $encryptedSecret
-     * @return string
-     */
     public static function decrypt(string $encryptedSecret): string
     {
         return self::getEncrypter()->decryptString($encryptedSecret);
     }
 
-    /**
-     * @return string
-     */
     public function getVariable(): string
     {
         return $this->variable;
     }
 
-    /**
-     * @return string
-     */
     public function getKey(): string
     {
         return $this->key;

--- a/src/SecretManager/SecretManager.php
+++ b/src/SecretManager/SecretManager.php
@@ -7,10 +7,6 @@ use Illuminate\Support\Facades\Config;
 
 class SecretManager
 {
-    /**
-     * @param $provider
-     * @return Collection
-     */
     public static function getSecrets($provider): Collection
     {
         // check if configuration wants all secrets or specific secrets

--- a/src/Services/ScrubberService.php
+++ b/src/Services/ScrubberService.php
@@ -9,10 +9,6 @@ use YorCreative\Scrubber\SecretManager\Secret;
 
 class ScrubberService
 {
-    /**
-     * @param $record
-     * @return string
-     */
     public static function encodeRecord($record): string
     {
         if (is_array($record)) {
@@ -22,10 +18,6 @@ class ScrubberService
         }
     }
 
-    /**
-     * @param $scrubbedContent
-     * @return mixed
-     */
     public static function decodeRecord($scrubbedContent): mixed
     {
         if (! is_array($scrubbedContent)) {
@@ -40,10 +32,6 @@ class ScrubberService
         return $scrubbedContent;
     }
 
-    /**
-     * @param  string  $jsonContent
-     * @return void
-     */
     public static function autoSanitize(string &$jsonContent): void
     {
         app(RegexRepository::class)->getRegexCollection()->each(function (RegexCollectionInterface $regexClass) use (&$jsonContent) {
@@ -55,10 +43,6 @@ class ScrubberService
         });
     }
 
-    /**
-     * @param  string  $regexPattern
-     * @param  string  $jsonContent
-     */
     protected static function patternChecker(string $regexPattern, string &$jsonContent): void
     {
         $hits = 0;

--- a/src/Services/SecretService.php
+++ b/src/Services/SecretService.php
@@ -9,24 +9,15 @@ use YorCreative\Scrubber\SecretManager\SecretManager;
 
 class SecretService
 {
-    /**
-     * @var array
-     */
     public static array $providers = [
         'gitlab' => Gitlab::class,
     ];
 
-    /**
-     * @return bool
-     */
     public static function isEnabled(): bool
     {
         return Config::get('scrubber.secret_manager.enabled') ?? false;
     }
 
-    /**
-     * @return Collection
-     */
     public static function getEnabledProviders(): Collection
     {
         $enabledProviders = new Collection();
@@ -39,10 +30,6 @@ class SecretService
         return $enabledProviders;
     }
 
-    /**
-     * @param  Collection  $providers
-     * @return Collection
-     */
     public static function loadSecrets(Collection $providers): Collection
     {
         $secrets = new Collection();

--- a/src/Strategies/RegexLoader/Loaders/DefaultCore.php
+++ b/src/Strategies/RegexLoader/Loaders/DefaultCore.php
@@ -10,17 +10,11 @@ use YorCreative\Scrubber\Strategies\RegexLoader\LoaderInterface;
 
 class DefaultCore implements LoaderInterface
 {
-    /**
-     * @return bool
-     */
     public function canLoad(): bool
     {
         return in_array('*', Config::get('scrubber.regex_loader'));
     }
 
-    /**
-     * @param  Collection  $collection
-     */
     public function load(Collection &$regexCollection): void
     {
         foreach (File::files(dirname(__DIR__, 3).'/RegexCollection') as $regexClass) {

--- a/src/Strategies/RegexLoader/Loaders/SecretLoader.php
+++ b/src/Strategies/RegexLoader/Loaders/SecretLoader.php
@@ -10,17 +10,11 @@ use YorCreative\Scrubber\Strategies\RegexLoader\LoaderInterface;
 
 class SecretLoader implements LoaderInterface
 {
-    /**
-     * @return bool
-     */
     public function canLoad(): bool
     {
         return SecretService::isEnabled();
     }
 
-    /**
-     * @param  Collection  $regexCollection
-     */
     public function load(Collection &$regexCollection): void
     {
         $providers = SecretService::getEnabledProviders();
@@ -32,10 +26,6 @@ class SecretLoader implements LoaderInterface
         });
     }
 
-    /**
-     * @param  Secret  $secret
-     * @return RegexCollectionInterface
-     */
     protected static function generateRegexClassForSecret(Secret $secret): RegexCollectionInterface
     {
         $class = new class implements RegexCollectionInterface

--- a/src/Strategies/RegexLoader/Loaders/SpecificCore.php
+++ b/src/Strategies/RegexLoader/Loaders/SpecificCore.php
@@ -9,17 +9,11 @@ use YorCreative\Scrubber\Strategies\RegexLoader\LoaderInterface;
 
 class SpecificCore implements LoaderInterface
 {
-    /**
-     * @return bool
-     */
     public function canLoad(): bool
     {
         return ! in_array('*', Config::get('scrubber.regex_loader'));
     }
 
-    /**
-     * @param  Collection  $regexCollection
-     */
     public function load(Collection &$regexCollection): void
     {
         foreach (Config::get('scrubber.regex_loader') as $regexClass) {

--- a/src/Strategies/RegexLoader/Loaders/SpecificExtendedRegex.php
+++ b/src/Strategies/RegexLoader/Loaders/SpecificExtendedRegex.php
@@ -10,9 +10,6 @@ use YorCreative\Scrubber\Strategies\RegexLoader\LoaderInterface;
 
 class SpecificExtendedRegex implements LoaderInterface
 {
-    /**
-     * @var string
-     */
     private string $path;
 
     public function __construct()
@@ -20,21 +17,21 @@ class SpecificExtendedRegex implements LoaderInterface
         $this->path = base_path('App/Scrubber/RegexCollection');
     }
 
-    /**
-     * @return bool
-     */
     public function canLoad(): bool
     {
-        return File::exists($this->path) && ! in_array('*', Config::get('scrubber.regex_loader'));
+        return File::exists($this->path)
+            && ! in_array('*', Config::get('scrubber.regex_loader'));
     }
 
-    /**
-     * @param  Collection  $regexCollection
-     */
     public function load(Collection &$regexCollection): void
     {
         foreach (File::files($this->path) as $regexClass) {
-            if (in_array($regexClass->getFilenameWithoutExtension(), Config::get('scrubber.regex_loader'))) {
+            $regexClassPath = 'App\\Scrubber\\RegexCollection\\'.$regexClass->getFilenameWithoutExtension();
+            $regexClassName = $regexClass->getFilenameWithoutExtension();
+            $configRegexLoader = Config::get('scrubber.regex_loader');
+
+            if (in_array($regexClassPath, $configRegexLoader)
+                || in_array($regexClassName, $configRegexLoader)) {
                 $regex = (new ('App\\Scrubber\\RegexCollection\\'.$regexClass->getFilenameWithoutExtension())());
 
                 $regexCollection = $regexCollection->merge([

--- a/src/Strategies/RegexLoader/Loaders/WildcardExtendedRegex.php
+++ b/src/Strategies/RegexLoader/Loaders/WildcardExtendedRegex.php
@@ -10,9 +10,6 @@ use YorCreative\Scrubber\Strategies\RegexLoader\LoaderInterface;
 
 class WildcardExtendedRegex implements LoaderInterface
 {
-    /**
-     * @var string
-     */
     private string $path;
 
     public function __construct()
@@ -20,17 +17,11 @@ class WildcardExtendedRegex implements LoaderInterface
         $this->path = base_path('App/Scrubber/RegexCollection');
     }
 
-    /**
-     * @return bool
-     */
     public function canLoad(): bool
     {
         return File::exists($this->path) && in_array('*', Config::get('scrubber.regex_loader'));
     }
 
-    /**
-     * @param  Collection  $regexCollection
-     */
     public function load(Collection &$regexCollection): void
     {
         foreach (File::files($this->path) as $regexClass) {

--- a/src/Strategies/RegexLoader/RegexLoaderStrategy.php
+++ b/src/Strategies/RegexLoader/RegexLoaderStrategy.php
@@ -6,9 +6,6 @@ use Illuminate\Support\Collection;
 
 class RegexLoaderStrategy
 {
-    /**
-     * @var Collection
-     */
     public Collection $availableLoaders;
 
     public function __construct()
@@ -16,23 +13,21 @@ class RegexLoaderStrategy
         $this->availableLoaders = new Collection();
     }
 
-    /**
-     * @param  LoaderInterface  $loader
-     */
     public function setLoader(LoaderInterface $loader): void
     {
         $this->availableLoaders->push($loader);
     }
 
-    /**
-     * @param  Collection  $regexCollection
-     */
-    public function load(Collection &$regexCollection): void
+    public function load(): Collection
     {
+        $regexCollection = new Collection();
+
         $this->availableLoaders->each(function ($loader) use (&$regexCollection) {
             if ($loader->canLoad()) {
                 $loader->load($regexCollection);
             }
         });
+
+        return $regexCollection;
     }
 }

--- a/src/Strategies/TapLoader/Loaders/DefaultChannels.php
+++ b/src/Strategies/TapLoader/Loaders/DefaultChannels.php
@@ -7,18 +7,12 @@ use YorCreative\Scrubber\Handlers\ScrubberTap;
 
 class DefaultChannels extends WildCardChannel
 {
-    /**
-     * @return bool
-     */
     final public function canLoad(): bool
     {
         return true;
     }
 
-    /**
-     * @param  Repository  $config
-     */
-    public function load(Repository &$config): void
+    public function load(Repository $config): void
     {
         $channels = $config->get('logging.channels');
 

--- a/src/Strategies/TapLoader/Loaders/MultipleChannel.php
+++ b/src/Strategies/TapLoader/Loaders/MultipleChannel.php
@@ -9,9 +9,6 @@ use YorCreative\Scrubber\Strategies\TapLoader\TapLoaderInterface;
 
 class MultipleChannel implements TapLoaderInterface
 {
-    /**
-     * @return bool
-     */
     public function canLoad(): bool
     {
         $channels = Config::get('scrubber.tap_channels');
@@ -23,10 +20,7 @@ class MultipleChannel implements TapLoaderInterface
             && count(Config::get('scrubber.tap_channels')) > 1;
     }
 
-    /**
-     * @param  Repository  $config
-     */
-    public function load(Repository &$config): void
+    public function load(Repository $config): void
     {
         foreach (Config::get('scrubber.tap_channels') as $channel) {
             $config->set("logging.channels.$channel.tap", [

--- a/src/Strategies/TapLoader/Loaders/SpecificChannel.php
+++ b/src/Strategies/TapLoader/Loaders/SpecificChannel.php
@@ -9,9 +9,6 @@ use YorCreative\Scrubber\Strategies\TapLoader\TapLoaderInterface;
 
 class SpecificChannel implements TapLoaderInterface
 {
-    /**
-     * @return bool
-     */
     public function canLoad(): bool
     {
         $channels = Config::get('scrubber.tap_channels');
@@ -23,10 +20,7 @@ class SpecificChannel implements TapLoaderInterface
             && count(Config::get('scrubber.tap_channels')) < 2;
     }
 
-    /**
-     * @param  Repository  $config
-     */
-    public function load(Repository &$config): void
+    public function load(Repository $config): void
     {
         $key = Config::get('scrubber.tap_channels')[0];
 

--- a/src/Strategies/TapLoader/Loaders/WildCardChannel.php
+++ b/src/Strategies/TapLoader/Loaders/WildCardChannel.php
@@ -9,9 +9,6 @@ use YorCreative\Scrubber\Strategies\TapLoader\TapLoaderInterface;
 
 class WildCardChannel implements TapLoaderInterface
 {
-    /**
-     * @return bool
-     */
     public function canLoad(): bool
     {
         $channels = Config::get('scrubber.tap_channels');
@@ -22,10 +19,7 @@ class WildCardChannel implements TapLoaderInterface
         return in_array('*', Config::get('scrubber.tap_channels'));
     }
 
-    /**
-     * @param  Repository  $config
-     */
-    public function load(Repository &$config): void
+    public function load(Repository $config): void
     {
         $channels = $config->get('logging.channels');
 

--- a/src/Strategies/TapLoader/TapLoaderInterface.php
+++ b/src/Strategies/TapLoader/TapLoaderInterface.php
@@ -8,5 +8,5 @@ interface TapLoaderInterface
 {
     public function canLoad(): bool;
 
-    public function load(Repository &$config): void;
+    public function load(Repository $config): void;
 }

--- a/src/Strategies/TapLoader/TapLoaderStrategy.php
+++ b/src/Strategies/TapLoader/TapLoaderStrategy.php
@@ -7,9 +7,6 @@ use Illuminate\Support\Collection;
 
 class TapLoaderStrategy
 {
-    /**
-     * @var Collection
-     */
     public Collection $availableLoaders;
 
     public function __construct()
@@ -17,20 +14,14 @@ class TapLoaderStrategy
         $this->availableLoaders = new Collection();
     }
 
-    /**
-     * @param  TapLoaderInterface  $loader
-     */
     public function setLoader(TapLoaderInterface $loader): void
     {
         $this->availableLoaders->push($loader);
     }
 
-    /**
-     * @param  Repository  $config
-     */
-    public function load(Repository &$config): void
+    public function load(Repository $config): void
     {
-        $this->availableLoaders->each(function ($loader) use (&$config) {
+        $this->availableLoaders->each(function ($loader) use ($config) {
             if ($loader->canLoad()) {
                 $loader->load($config);
             }

--- a/tests/Unit/Strategies/RegexLoaderStrategyTest.php
+++ b/tests/Unit/Strategies/RegexLoaderStrategyTest.php
@@ -2,11 +2,10 @@
 
 namespace YorCreative\Scrubber\Test\Unit\Strategies;
 
-use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Config;
+use YorCreative\Scrubber\Tests\TestCase;
 use YorCreative\Scrubber\Repositories\RegexCollection;
 use YorCreative\Scrubber\Strategies\RegexLoader\RegexLoaderStrategy;
-use YorCreative\Scrubber\Tests\TestCase;
 
 class RegexLoaderStrategyTest extends TestCase
 {
@@ -18,10 +17,7 @@ class RegexLoaderStrategyTest extends TestCase
      */
     public function it_can_load_default_core()
     {
-        $regexClasses = new Collection();
-        app(RegexLoaderStrategy::class)->load($regexClasses);
-
-        $this->assertCount(25, $regexClasses);
+        $this->assertCount(25, app(RegexLoaderStrategy::class)->load());
     }
 
     /**
@@ -33,9 +29,7 @@ class RegexLoaderStrategyTest extends TestCase
     public function it_can_load_specific_core()
     {
         Config::set('scrubber.regex_loader', [RegexCollection::$GOOGLE_API]);
-        $regexClasses = new Collection();
-        app(RegexLoaderStrategy::class)->load($regexClasses);
 
-        $this->assertCount(1, $regexClasses);
+        $this->assertCount(1, app(RegexLoaderStrategy::class)->load());
     }
 }

--- a/tests/Unit/Strategies/RegexLoaderStrategyTest.php
+++ b/tests/Unit/Strategies/RegexLoaderStrategyTest.php
@@ -3,9 +3,9 @@
 namespace YorCreative\Scrubber\Test\Unit\Strategies;
 
 use Illuminate\Support\Facades\Config;
-use YorCreative\Scrubber\Tests\TestCase;
 use YorCreative\Scrubber\Repositories\RegexCollection;
 use YorCreative\Scrubber\Strategies\RegexLoader\RegexLoaderStrategy;
+use YorCreative\Scrubber\Tests\TestCase;
 
 class RegexLoaderStrategyTest extends TestCase
 {


### PR DESCRIPTION
**The oof**😨 
When the TapLoaderStrategy was implemented, the load() function was not being initiated. 
As a result, log events were not being captured and sanitized by the Scrubber package.

**Root Cause**🕵🏼
The root cause of the bug was a missing line of code in the boot() function of the `ScrubberServiceProvider`.

```php
$this->app->make(TapLoaderStrategy::class)->load($this->app->make('config'));
```
🖖🏼 