### PR TITLE
bug fix: path was failing on laravel 9 on Linux file system

### DIFF
--- a/src/Strategies/RegexLoader/Loaders/SpecificExtendedRegex.php
+++ b/src/Strategies/RegexLoader/Loaders/SpecificExtendedRegex.php
@@ -14,7 +14,7 @@ class SpecificExtendedRegex implements LoaderInterface
 
     public function __construct()
     {
-        $this->path = base_path('App/Scrubber/RegexCollection');
+        $this->path = base_path('app/Scrubber/RegexCollection');
     }
 
     public function canLoad(): bool


### PR DESCRIPTION
Hello @yordadev, @Magentron , @LorenzoSapora ,
There was a bug when moving to prod on linux. Due to the case sensitivity of linux file system, this was failing because laravel's 'app' folder is in lower case while your app was looking for one in uppercase.  