### PR TITLE
[Patch] NullHandler class cannot be tapped.

### DIFF
--- a/src/Handlers/ScrubberTap.php
+++ b/src/Handlers/ScrubberTap.php
@@ -9,9 +9,12 @@ class ScrubberTap
     public function __invoke($logger)
     {
         foreach ($logger->getHandlers() as $handler) {
-            $handler->pushProcessor(function ($record) {
-                return Scrubber::processMessage($record);
-            });
+            if (!($handler instanceof \Monolog\Handler\NullHandler)) {
+                $handler->pushProcessor(function ($record) {
+                    return Scrubber::processMessage($record);
+                });
+            }
         }
     }
 }
+

--- a/src/Handlers/ScrubberTap.php
+++ b/src/Handlers/ScrubberTap.php
@@ -9,7 +9,7 @@ class ScrubberTap
     public function __invoke($logger)
     {
         foreach ($logger->getHandlers() as $handler) {
-            if (!($handler instanceof \Monolog\Handler\NullHandler)) {
+            if (! ($handler instanceof \Monolog\Handler\NullHandler)) {
                 $handler->pushProcessor(function ($record) {
                     return Scrubber::processMessage($record);
                 });
@@ -17,4 +17,3 @@ class ScrubberTap
         }
     }
 }
-


### PR DESCRIPTION
Small adjustment to the ScrubberTap class to skip the NullHandler class when tapping into Laravel's logging functionality.

This PR, contributed by @Magentron, addresses the issue with tapping into the NullHandler class in Laravel's logging functionality. https://github.com/YorCreative/Laravel-Scrubber/issues/29 highlighted that tapping into the NullHandler can cause errors and issues.

To resolve this issue, this PR makes a small adjustment to the ScrubberTap class. The change checks if the handler is not an instance of NullHandler before pushing the message processing function to the handler, ensuring that the NullHandler is not tapped as it cannot be tapped. This helps to avoid any potential errors or issues that may arise from attempting to tap the NullHandler.

Thanks to @Magentron for contributing this fix.