### PR TITLE
[Patch] Log Record Updates

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -17,8 +17,6 @@ jobs:
             testbench: 8
           - laravel: 9.*
             testbench: 7.*
-          - laravel: 8.*
-            testbench: 6.*
 
     name: PHP${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         php: [8.1, 8.2]
-        laravel: [8.*, 9.*, 10.*]
+        laravel: [9.*, 10.*]
         include:
           - laravel: 10.*
             testbench: 8

--- a/README.md
+++ b/README.md
@@ -252,5 +252,7 @@ composer test
 
 - [Yorda](https://github.com/yordadev)
 - [Whizboy-Arnold](https://github.com/Whizboy-Arnold)
+- [majchrosoft](https://github.com/majchrosoft)
+- [Lucaxue](https://github.com/lucaxue)
 - [All Contributors](../../contributors)
 

--- a/composer.json
+++ b/composer.json
@@ -17,14 +17,14 @@
     "minimum-stability": "dev",
     "require": {
         "php": "^8.1",
-        "illuminate/contracts": "^10.0",
-        "monolog/monolog": "^3",
+        "illuminate/contracts": "^9.0|^10.0",
+        "monolog/monolog": "^2.0|^3",
         "guzzlehttp/guzzle": "^7.4.5"
     },
     "require-dev": {
         "ext-pdo_sqlite": "*",
         "laravel/pint": "^1.0",
-        "orchestra/testbench": "^8.4",
+        "orchestra/testbench": "^7.0|^8.4",
         "phpunit/phpunit": "^9"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "ext-pdo_sqlite": "*",
         "laravel/pint": "^1.0",
         "orchestra/testbench": "^7.0|^8.4",
-        "phpunit/phpunit": "^9"
+        "phpunit/phpunit": "^9.5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -17,14 +17,15 @@
     "minimum-stability": "dev",
     "require": {
         "php": "^8.1",
-        "illuminate/contracts": "^8.0|^9.0|^10.0",
+        "illuminate/contracts": "^10.0",
+        "monolog/monolog": "^3",
         "guzzlehttp/guzzle": "^7.4.5"
     },
     "require-dev": {
         "ext-pdo_sqlite": "*",
         "laravel/pint": "^1.0",
-        "orchestra/testbench": "^7.0",
-        "phpunit/phpunit": "^9.5"
+        "orchestra/testbench": "^8.4",
+        "phpunit/phpunit": "^9"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "df6431162dd8c3963f78de35326a31d2",
+    "content-hash": "6daac4ad1b0082ee6ce27a1dca804892",
     "packages": [
         {
             "name": "brick/math",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "73aaeeadeff363adf9e0ff45685213bd",
+    "content-hash": "df6431162dd8c3963f78de35326a31d2",
     "packages": [
         {
             "name": "brick/math",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "31ed84238771317cb1ffead3199322f9",
+    "content-hash": "73aaeeadeff363adf9e0ff45685213bd",
     "packages": [
         {
             "name": "brick/math",
@@ -979,20 +979,21 @@
         },
         {
             "name": "laravel/framework",
-            "version": "9.x-dev",
+            "version": "10.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "e217dca49e20cd2840970f8d307c8392012bc5be"
+                "reference": "ac3fecd58ba88858d7560e99643a5790cfb5ca6c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/e217dca49e20cd2840970f8d307c8392012bc5be",
-                "reference": "e217dca49e20cd2840970f8d307c8392012bc5be",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/ac3fecd58ba88858d7560e99643a5790cfb5ca6c",
+                "reference": "ac3fecd58ba88858d7560e99643a5790cfb5ca6c",
                 "shasum": ""
             },
             "require": {
                 "brick/math": "^0.9.3|^0.10.2|^0.11",
+                "composer-runtime-api": "^2.2",
                 "doctrine/inflector": "^2.0.5",
                 "dragonmantank/cron-expression": "^3.3.2",
                 "egulias/email-validator": "^3.2.1|^4.0",
@@ -1005,28 +1006,28 @@
                 "ext-tokenizer": "*",
                 "fruitcake/php-cors": "^1.2",
                 "guzzlehttp/uri-template": "^1.0",
-                "laravel/serializable-closure": "^1.2.2",
+                "laravel/serializable-closure": "^1.3",
                 "league/commonmark": "^2.2.1",
                 "league/flysystem": "^3.8.0",
-                "monolog/monolog": "^2.0",
+                "monolog/monolog": "^3.0",
                 "nesbot/carbon": "^2.62.1",
                 "nunomaduro/termwind": "^1.13",
-                "php": "^8.0.2",
+                "php": "^8.1",
                 "psr/container": "^1.1.1|^2.0.1",
                 "psr/log": "^1.0|^2.0|^3.0",
                 "psr/simple-cache": "^1.0|^2.0|^3.0",
                 "ramsey/uuid": "^4.7",
-                "symfony/console": "^6.0.9",
-                "symfony/error-handler": "^6.0",
-                "symfony/finder": "^6.0",
-                "symfony/http-foundation": "^6.0",
-                "symfony/http-kernel": "^6.0",
-                "symfony/mailer": "^6.0",
-                "symfony/mime": "^6.0",
-                "symfony/process": "^6.0",
-                "symfony/routing": "^6.0",
-                "symfony/uid": "^6.0",
-                "symfony/var-dumper": "^6.0",
+                "symfony/console": "^6.2",
+                "symfony/error-handler": "^6.2",
+                "symfony/finder": "^6.2",
+                "symfony/http-foundation": "^6.2",
+                "symfony/http-kernel": "^6.2",
+                "symfony/mailer": "^6.2",
+                "symfony/mime": "^6.2",
+                "symfony/process": "^6.2",
+                "symfony/routing": "^6.2",
+                "symfony/uid": "^6.2",
+                "symfony/var-dumper": "^6.2",
                 "tijsverkoyen/css-to-inline-styles": "^2.2.5",
                 "vlucas/phpdotenv": "^5.4.1",
                 "voku/portable-ascii": "^2.0"
@@ -1062,6 +1063,7 @@
                 "illuminate/notifications": "self.version",
                 "illuminate/pagination": "self.version",
                 "illuminate/pipeline": "self.version",
+                "illuminate/process": "self.version",
                 "illuminate/queue": "self.version",
                 "illuminate/redis": "self.version",
                 "illuminate/routing": "self.version",
@@ -1075,7 +1077,7 @@
             "require-dev": {
                 "ably/ably-php": "^1.0",
                 "aws/aws-sdk-php": "^3.235.5",
-                "doctrine/dbal": "^2.13.3|^3.1.4",
+                "doctrine/dbal": "^3.5.1",
                 "ext-gmp": "*",
                 "fakerphp/faker": "^1.21",
                 "guzzlehttp/guzzle": "^7.5",
@@ -1085,20 +1087,20 @@
                 "league/flysystem-read-only": "^3.3",
                 "league/flysystem-sftp-v3": "^3.0",
                 "mockery/mockery": "^1.5.1",
-                "orchestra/testbench-core": "^7.24",
+                "orchestra/testbench-core": "^8.4",
                 "pda/pheanstalk": "^4.0",
                 "phpstan/phpdoc-parser": "^1.15",
                 "phpstan/phpstan": "^1.4.7",
-                "phpunit/phpunit": "^9.5.8",
-                "predis/predis": "^1.1.9|^2.0.2",
-                "symfony/cache": "^6.0",
-                "symfony/http-client": "^6.0"
+                "phpunit/phpunit": "^10.0.7",
+                "predis/predis": "^2.0.2",
+                "symfony/cache": "^6.2",
+                "symfony/http-client": "^6.2.4"
             },
             "suggest": {
                 "ably/ably-php": "Required to use the Ably broadcast driver (^1.0).",
                 "aws/aws-sdk-php": "Required to use the SQS queue driver, DynamoDb failed job storage, and SES mail driver (^3.235.5).",
                 "brianium/paratest": "Required to run tests in parallel (^6.0).",
-                "doctrine/dbal": "Required to rename columns and drop SQLite columns (^2.13.3|^3.1.4).",
+                "doctrine/dbal": "Required to rename columns and drop SQLite columns (^3.5.1).",
                 "ext-apcu": "Required to use the APC cache driver.",
                 "ext-fileinfo": "Required to use the Filesystem class.",
                 "ext-ftp": "Required to use the Flysystem FTP driver.",
@@ -1120,21 +1122,22 @@
                 "mockery/mockery": "Required to use mocking (^1.5.1).",
                 "nyholm/psr7": "Required to use PSR-7 bridging features (^1.2).",
                 "pda/pheanstalk": "Required to use the beanstalk queue driver (^4.0).",
-                "phpunit/phpunit": "Required to use assertions and run tests (^9.5.8).",
-                "predis/predis": "Required to use the predis connector (^1.1.9|^2.0.2).",
+                "phpunit/phpunit": "Required to use assertions and run tests (^9.5.8|^10.0.7).",
+                "predis/predis": "Required to use the predis connector (^2.0.2).",
                 "psr/http-message": "Required to allow Storage::put to accept a StreamInterface (^1.0).",
                 "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^6.0|^7.0).",
-                "symfony/cache": "Required to PSR-6 cache bridge (^6.0).",
-                "symfony/filesystem": "Required to enable support for relative symbolic links (^6.0).",
-                "symfony/http-client": "Required to enable support for the Symfony API mail transports (^6.0).",
-                "symfony/mailgun-mailer": "Required to enable support for the Mailgun mail transport (^6.0).",
-                "symfony/postmark-mailer": "Required to enable support for the Postmark mail transport (^6.0).",
+                "symfony/cache": "Required to PSR-6 cache bridge (^6.2).",
+                "symfony/filesystem": "Required to enable support for relative symbolic links (^6.2).",
+                "symfony/http-client": "Required to enable support for the Symfony API mail transports (^6.2).",
+                "symfony/mailgun-mailer": "Required to enable support for the Mailgun mail transport (^6.2).",
+                "symfony/postmark-mailer": "Required to enable support for the Postmark mail transport (^6.2).",
                 "symfony/psr-http-message-bridge": "Required to use PSR-7 bridging features (^2.0)."
             },
+            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.x-dev"
+                    "dev-master": "10.x-dev"
                 }
             },
             "autoload": {
@@ -1173,7 +1176,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2023-06-11T21:17:39+00:00"
+            "time": "2023-06-20T19:46:51+00:00"
         },
         {
             "name": "laravel/serializable-closure",
@@ -1633,42 +1636,41 @@
         },
         {
             "name": "monolog/monolog",
-            "version": "2.x-dev",
+            "version": "dev-main",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "f259e2b15fb95494c83f52d3caad003bbf5ffaa1"
+                "reference": "1fd8e8c2c75ab9d1e2cf8227cb078815b249ca75"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/f259e2b15fb95494c83f52d3caad003bbf5ffaa1",
-                "reference": "f259e2b15fb95494c83f52d3caad003bbf5ffaa1",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/1fd8e8c2c75ab9d1e2cf8227cb078815b249ca75",
+                "reference": "1fd8e8c2c75ab9d1e2cf8227cb078815b249ca75",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2",
-                "psr/log": "^1.0.1 || ^2.0 || ^3.0"
+                "php": ">=8.1",
+                "psr/log": "^2.0 || ^3.0"
             },
             "provide": {
-                "psr/log-implementation": "1.0.0 || 2.0.0 || 3.0.0"
+                "psr/log-implementation": "3.0.0"
             },
             "require-dev": {
-                "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                "aws/aws-sdk-php": "^3.0",
                 "doctrine/couchdb": "~1.0@dev",
                 "elasticsearch/elasticsearch": "^7 || ^8",
                 "ext-json": "*",
-                "graylog2/gelf-php": "^1.4.2 || ^2@dev",
-                "guzzlehttp/guzzle": "^7.4",
+                "graylog2/gelf-php": "^1.4.2 || ^2.0",
+                "guzzlehttp/guzzle": "^7.4.5",
                 "guzzlehttp/psr7": "^2.2",
                 "mongodb/mongodb": "^1.8",
                 "php-amqplib/php-amqplib": "~2.4 || ^3",
-                "phpspec/prophecy": "^1.15",
-                "phpstan/phpstan": "^0.12.91",
-                "phpunit/phpunit": "^8.5.14",
-                "predis/predis": "^1.1 || ^2.0",
-                "rollbar/rollbar": "^1.3 || ^2 || ^3",
+                "phpstan/phpstan": "^1.9",
+                "phpstan/phpstan-deprecation-rules": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.4",
+                "phpunit/phpunit": "^10.1",
+                "predis/predis": "^1.1 || ^2",
                 "ruflin/elastica": "^7",
-                "swiftmailer/swiftmailer": "^5.3|^6.0",
                 "symfony/mailer": "^5.4 || ^6",
                 "symfony/mime": "^5.4 || ^6"
             },
@@ -1688,10 +1690,11 @@
                 "rollbar/rollbar": "Allow sending log messages to Rollbar",
                 "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
             },
+            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.x-dev"
+                    "dev-main": "3.x-dev"
                 }
             },
             "autoload": {
@@ -1719,7 +1722,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Seldaek/monolog/issues",
-                "source": "https://github.com/Seldaek/monolog/tree/2.x"
+                "source": "https://github.com/Seldaek/monolog/tree/main"
             },
             "funding": [
                 {
@@ -1731,7 +1734,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-06T13:44:46+00:00"
+            "time": "2023-06-20T14:42:38+00:00"
         },
         {
             "name": "nesbot/carbon",
@@ -2753,12 +2756,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "845f20181c7f11ca9564490cc791c2fe91d443ef"
+                "reference": "c7082ff6400cc82b0e950ee31e8e77d76232af1f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/845f20181c7f11ca9564490cc791c2fe91d443ef",
-                "reference": "845f20181c7f11ca9564490cc791c2fe91d443ef",
+                "url": "https://api.github.com/repos/symfony/console/zipball/c7082ff6400cc82b0e950ee31e8e77d76232af1f",
+                "reference": "c7082ff6400cc82b0e950ee31e8e77d76232af1f",
                 "shasum": ""
             },
             "require": {
@@ -2835,7 +2838,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-30T17:17:10+00:00"
+            "time": "2023-06-20T10:30:43+00:00"
         },
         {
             "name": "symfony/css-selector",
@@ -3348,12 +3351,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "f4da06d8657772e15eec26095dbd5c705606d290"
+                "reference": "45516b6d06c4696468c1bf6eae8afaf3752e9a8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/f4da06d8657772e15eec26095dbd5c705606d290",
-                "reference": "f4da06d8657772e15eec26095dbd5c705606d290",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/45516b6d06c4696468c1bf6eae8afaf3752e9a8c",
+                "reference": "45516b6d06c4696468c1bf6eae8afaf3752e9a8c",
                 "shasum": ""
             },
             "require": {
@@ -3453,7 +3456,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-06-03T15:11:12+00:00"
+            "time": "2023-06-20T15:03:27+00:00"
         },
         {
             "name": "symfony/mailer",
@@ -4429,12 +4432,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "1342e2fafef1c6292103c65be82a63cf763ccfeb"
+                "reference": "d02d2c4bfc9e5bac947a675e893c13ac9031f902"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/1342e2fafef1c6292103c65be82a63cf763ccfeb",
-                "reference": "1342e2fafef1c6292103c65be82a63cf763ccfeb",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/d02d2c4bfc9e5bac947a675e893c13ac9031f902",
+                "reference": "d02d2c4bfc9e5bac947a675e893c13ac9031f902",
                 "shasum": ""
             },
             "require": {
@@ -4503,7 +4506,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-06-05T15:30:34+00:00"
+            "time": "2023-06-20T10:37:57+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -5469,16 +5472,16 @@
         },
         {
             "name": "laravel/pint",
-            "version": "v1.10.2",
+            "version": "v1.10.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/pint.git",
-                "reference": "f78de1a1bbab7aa41a6ea211c5962b0530d1a301"
+                "reference": "c472786bca01e4812a9bb7933b23edfc5b6877b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/pint/zipball/f78de1a1bbab7aa41a6ea211c5962b0530d1a301",
-                "reference": "f78de1a1bbab7aa41a6ea211c5962b0530d1a301",
+                "url": "https://api.github.com/repos/laravel/pint/zipball/c472786bca01e4812a9bb7933b23edfc5b6877b7",
+                "reference": "c472786bca01e4812a9bb7933b23edfc5b6877b7",
                 "shasum": ""
             },
             "require": {
@@ -5489,7 +5492,7 @@
                 "php": "^8.1.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.17.0",
+                "friendsofphp/php-cs-fixer": "^3.18.0",
                 "illuminate/view": "^10.5.1",
                 "laravel-zero/framework": "^10.0.2",
                 "mockery/mockery": "^1.5.1",
@@ -5531,7 +5534,7 @@
                 "issues": "https://github.com/laravel/pint/issues",
                 "source": "https://github.com/laravel/pint"
             },
-            "time": "2023-06-12T10:50:04+00:00"
+            "time": "2023-06-20T15:55:03+00:00"
         },
         {
             "name": "mockery/mockery",
@@ -5732,36 +5735,32 @@
         },
         {
             "name": "orchestra/testbench",
-            "version": "7.x-dev",
+            "version": "8.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/orchestral/testbench.git",
-                "reference": "35956b9a678c95fd1cb73769e94c5699237864c2"
+                "reference": "a74b9e019c9d7283cf51b0ce495315c653c0f4de"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/orchestral/testbench/zipball/35956b9a678c95fd1cb73769e94c5699237864c2",
-                "reference": "35956b9a678c95fd1cb73769e94c5699237864c2",
+                "url": "https://api.github.com/repos/orchestral/testbench/zipball/a74b9e019c9d7283cf51b0ce495315c653c0f4de",
+                "reference": "a74b9e019c9d7283cf51b0ce495315c653c0f4de",
                 "shasum": ""
             },
             "require": {
+                "composer-runtime-api": "^2.2",
                 "fakerphp/faker": "^1.21",
-                "laravel/framework": "^9.52.9",
+                "laravel/framework": ">=10.13.5 <10.14.0 || 10.x-dev",
                 "mockery/mockery": "^1.5.1",
-                "orchestra/testbench-core": "^7.25",
-                "php": "^8.0",
-                "phpunit/phpunit": "^9.5.10",
+                "orchestra/testbench-core": ">=8.5.7 <8.6.0 || 8.x-dev",
+                "php": "^8.1",
+                "phpunit/phpunit": "^9.6 || ^10.1",
                 "spatie/laravel-ray": "^1.32.4",
-                "symfony/process": "^6.0.9",
-                "symfony/yaml": "^6.0.9",
+                "symfony/process": "^6.2",
+                "symfony/yaml": "^6.2",
                 "vlucas/phpdotenv": "^5.4.1"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "7.0-dev"
-                }
-            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
@@ -5785,60 +5784,57 @@
             ],
             "support": {
                 "issues": "https://github.com/orchestral/testbench/issues",
-                "source": "https://github.com/orchestral/testbench/tree/7.x"
+                "source": "https://github.com/orchestral/testbench/tree/8.x"
             },
-            "time": "2023-06-13T06:00:26+00:00"
+            "time": "2023-06-14T12:14:27+00:00"
         },
         {
             "name": "orchestra/testbench-core",
-            "version": "7.x-dev",
+            "version": "8.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/orchestral/testbench-core.git",
-                "reference": "d5da4c5733ede2c39658adedc45fa74e15f8c957"
+                "reference": "5f035c104673542909d6e4912202aa357419aa69"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/orchestral/testbench-core/zipball/d5da4c5733ede2c39658adedc45fa74e15f8c957",
-                "reference": "d5da4c5733ede2c39658adedc45fa74e15f8c957",
+                "url": "https://api.github.com/repos/orchestral/testbench-core/zipball/5f035c104673542909d6e4912202aa357419aa69",
+                "reference": "5f035c104673542909d6e4912202aa357419aa69",
                 "shasum": ""
             },
             "require": {
-                "php": "^8.0"
+                "composer-runtime-api": "^2.2",
+                "php": "^8.1"
             },
             "require-dev": {
                 "fakerphp/faker": "^1.21",
-                "laravel/framework": "^9.52.9",
-                "laravel/pint": "^1.4",
+                "laravel/framework": "^10.13.5",
+                "laravel/pint": "^1.6",
                 "mockery/mockery": "^1.5.1",
                 "phpstan/phpstan": "^1.10.7",
-                "phpunit/phpunit": "^9.5.10",
+                "phpunit/phpunit": "^10.1",
                 "spatie/laravel-ray": "^1.32.4",
-                "symfony/process": "^6.0.9",
-                "symfony/yaml": "^6.0.9",
+                "symfony/process": "^6.2",
+                "symfony/yaml": "^6.2",
                 "vlucas/phpdotenv": "^5.4.1"
             },
             "suggest": {
-                "brianium/paratest": "Allow using parallel tresting (^6.4).",
+                "brianium/paratest": "Allow using parallel tresting (^6.4 || ^7.1.4).",
                 "fakerphp/faker": "Allow using Faker for testing (^1.21).",
-                "laravel/framework": "Required for testing (^9.52.9).",
+                "laravel/framework": "Required for testing (^10.13.5).",
                 "mockery/mockery": "Allow using Mockery for testing (^1.5.1).",
-                "nunomaduro/collision": "Allow using Laravel style tests output and parallel testing (^6.2).",
-                "orchestra/testbench-browser-kit": "Allow using legacy Laravel BrowserKit for testing (^7.0).",
-                "orchestra/testbench-dusk": "Allow using Laravel Dusk for testing (^7.0).",
-                "phpunit/phpunit": "Allow using PHPUnit for testing (^9.5.10).",
-                "symfony/yaml": "Required for CLI Commander (^6.0.9).",
+                "nunomaduro/collision": "Allow using Laravel style tests output and parallel testing (^6.4 || ^7.4).",
+                "orchestra/testbench-browser-kit": "Allow using legacy Laravel BrowserKit for testing (^8.0).",
+                "orchestra/testbench-dusk": "Allow using Laravel Dusk for testing (^8.0).",
+                "phpunit/phpunit": "Allow using PHPUnit for testing (^9.6 || ^10.1).",
+                "symfony/yaml": "Required for CLI Commander (^6.2).",
                 "vlucas/phpdotenv": "Required for CLI Commander (^5.4.1)."
             },
+            "default-branch": true,
             "bin": [
                 "testbench"
             ],
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "7.0-dev"
-                }
-            },
             "autoload": {
                 "files": [
                     "src/helpers.php"
@@ -5872,7 +5868,7 @@
                 "issues": "https://github.com/orchestral/testbench/issues",
                 "source": "https://github.com/orchestral/testbench-core"
             },
-            "time": "2023-06-13T05:37:48+00:00"
+            "time": "2023-06-20T03:32:57+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -5999,12 +5995,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "100663232669bdacd3ac18f4cc12c38beec9aff1"
+                "reference": "b99350b5b43439295d740bce1425fba31fa7c22d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/100663232669bdacd3ac18f4cc12c38beec9aff1",
-                "reference": "100663232669bdacd3ac18f4cc12c38beec9aff1",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/b99350b5b43439295d740bce1425fba31fa7c22d",
+                "reference": "b99350b5b43439295d740bce1425fba31fa7c22d",
                 "shasum": ""
             },
             "require": {
@@ -6069,7 +6065,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-05-25T06:20:28+00:00"
+            "time": "2023-06-19T06:40:06+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -6318,12 +6314,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "a9aceaf20a682aeacf28d582654a1670d8826778"
+                "reference": "26ad1b9e87ef46650e951945c7d48659788f0950"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a9aceaf20a682aeacf28d582654a1670d8826778",
-                "reference": "a9aceaf20a682aeacf28d582654a1670d8826778",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/26ad1b9e87ef46650e951945c7d48659788f0950",
+                "reference": "26ad1b9e87ef46650e951945c7d48659788f0950",
                 "shasum": ""
             },
             "require": {
@@ -6397,7 +6393,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.9"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6"
             },
             "funding": [
                 {
@@ -6413,7 +6409,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-06-11T06:13:56+00:00"
+            "time": "2023-06-19T06:33:11+00:00"
         },
         {
             "name": "pimple/pimple",

--- a/src/Repositories/RegexRepository.php
+++ b/src/Repositories/RegexRepository.php
@@ -16,6 +16,11 @@ class RegexRepository
         return preg_replace("~$regex~i", config('scrubber.redaction'), $content, -1, $hits);
     }
 
+    public static function check(string $regex, string $content, int &$hits = 0): bool
+    {
+        return preg_match("~$regex~i", $content,$hits);
+    }
+
     public function getRegexCollection(): Collection
     {
         return $this->regexCollection;

--- a/src/Repositories/RegexRepository.php
+++ b/src/Repositories/RegexRepository.php
@@ -16,7 +16,6 @@ class RegexRepository
         return preg_replace("~$regex~i", config('scrubber.redaction'), $content, -1, $hits);
     }
 
-
     public static function check(string $regex, string $content): int
     {
         return preg_match_all("~$regex~i", $content);

--- a/src/Repositories/RegexRepository.php
+++ b/src/Repositories/RegexRepository.php
@@ -16,9 +16,10 @@ class RegexRepository
         return preg_replace("~$regex~i", config('scrubber.redaction'), $content, -1, $hits);
     }
 
-    public static function check(string $regex, string $content, int &$hits = 0): bool
+
+    public static function check(string $regex, string $content): int
     {
-        return preg_match("~$regex~i", $content,$hits);
+        return preg_match_all("~$regex~i", $content);
     }
 
     public function getRegexCollection(): Collection

--- a/src/Scrubber.php
+++ b/src/Scrubber.php
@@ -3,6 +3,8 @@
 namespace YorCreative\Scrubber;
 
 use Monolog\LogRecord;
+use YorCreative\Scrubber\Repositories\RegexRepository;
+use YorCreative\Scrubber\Services\ScrubberService;
 use YorCreative\Scrubber\Strategies\ContentProcessingStrategy\ContentProcessingStrategy;
 
 class Scrubber
@@ -10,5 +12,10 @@ class Scrubber
     public static function processMessage($content): array|string|LogRecord
     {
         return app()->get(ContentProcessingStrategy::class)->processContent($content);
+    }
+
+    public static function getRegexRepository(): RegexRepository
+    {
+        return ScrubberService::getRegexRepository();
     }
 }

--- a/src/Scrubber.php
+++ b/src/Scrubber.php
@@ -2,51 +2,13 @@
 
 namespace YorCreative\Scrubber;
 
-use YorCreative\Scrubber\Services\ScrubberService;
+use Monolog\LogRecord;
+use YorCreative\Scrubber\Strategies\ContentProcessingStrategy\ContentProcessingStrategy;
 
 class Scrubber
 {
-    public static function processMessage($content): array|string
+    public static function processMessage($content): array|string|LogRecord
     {
-        return is_array($content)
-            ? self::processArray($content)
-            : self::processString($content);
-    }
-
-    private static function processArray(array $content): array
-    {
-        $jsonContent = ScrubberService::encodeRecord($content);
-        if ('' === $jsonContent) {
-            // failed to convert array to JSON, so process array recursively
-            return self::processArrayRecursively($content);
-        }
-
-        ScrubberService::autoSanitize($jsonContent);
-
-        return ScrubberService::decodeRecord($jsonContent);
-    }
-
-    private static function processArrayRecursively(array $content): array
-    {
-        foreach ($content as $key => $value) {
-            if (null !== $value) {
-                if (is_array($value)) {
-                    $content[$key] = self::processArray($value);
-                } elseif (is_object($value) && ! method_exists($value, '__toString')) {
-                    $content[$key] = self::processArray((array) $value);
-                } else {
-                    $content[$key] = self::processString((string) $value);
-                }
-            }
-        }
-
-        return $content;
-    }
-
-    private static function processString($content): string
-    {
-        ScrubberService::autoSanitize($content);
-
-        return $content;
+        return app()->get(ContentProcessingStrategy::class)->processContent($content);
     }
 }

--- a/src/ScrubberServiceProvider.php
+++ b/src/ScrubberServiceProvider.php
@@ -7,6 +7,10 @@ use Illuminate\Support\Facades\Config;
 use Illuminate\Support\ServiceProvider;
 use YorCreative\Scrubber\Clients\GitLabClient;
 use YorCreative\Scrubber\Repositories\RegexRepository;
+use YorCreative\Scrubber\Strategies\ContentProcessingStrategy\ContentProcessingStrategy;
+use YorCreative\Scrubber\Strategies\ContentProcessingStrategy\Handlers\ArrayContentHandler;
+use YorCreative\Scrubber\Strategies\ContentProcessingStrategy\Handlers\LogRecordContentHandler;
+use YorCreative\Scrubber\Strategies\ContentProcessingStrategy\Handlers\StringContentHandler;
 use YorCreative\Scrubber\Strategies\RegexLoader\Loaders\DefaultCore;
 use YorCreative\Scrubber\Strategies\RegexLoader\Loaders\SecretLoader;
 use YorCreative\Scrubber\Strategies\RegexLoader\Loaders\SpecificCore;
@@ -50,6 +54,7 @@ class ScrubberServiceProvider extends ServiceProvider
                 ]));
             });
         }
+
         $this->app->singleton(RegexLoaderStrategy::class, function () {
             $regexLoaderStrategy = new RegexLoaderStrategy();
             $regexLoaderStrategy->setLoader(new DefaultCore());
@@ -75,6 +80,16 @@ class ScrubberServiceProvider extends ServiceProvider
 
         $this->app->scoped(RegexRepository::class, function ($app) {
             return new RegexRepository($app->make(RegexLoaderStrategy::class)->load());
+        });
+
+        $this->app->singleton(ContentProcessingStrategy::class, function(){
+            $contentProcessingStrategy = new ContentProcessingStrategy();
+
+            $contentProcessingStrategy->setHandler(new StringContentHandler());
+            $contentProcessingStrategy->setHandler(new ArrayContentHandler());
+            $contentProcessingStrategy->setHandler(new LogRecordContentHandler());
+
+            return $contentProcessingStrategy;
         });
     }
 }

--- a/src/ScrubberServiceProvider.php
+++ b/src/ScrubberServiceProvider.php
@@ -82,7 +82,7 @@ class ScrubberServiceProvider extends ServiceProvider
             return new RegexRepository($app->make(RegexLoaderStrategy::class)->load());
         });
 
-        $this->app->singleton(ContentProcessingStrategy::class, function(){
+        $this->app->singleton(ContentProcessingStrategy::class, function () {
             $contentProcessingStrategy = new ContentProcessingStrategy();
 
             $contentProcessingStrategy->setHandler(new StringContentHandler());

--- a/src/Services/ScrubberService.php
+++ b/src/Services/ScrubberService.php
@@ -61,4 +61,9 @@ class ScrubberService
          *
          **/
     }
+
+    public static function getRegexRepository(): RegexRepository
+    {
+        return app()->get(RegexRepository::class);
+    }
 }

--- a/src/Services/ScrubberService.php
+++ b/src/Services/ScrubberService.php
@@ -3,6 +3,7 @@
 namespace YorCreative\Scrubber\Services;
 
 use Carbon\Carbon;
+use Monolog\LogRecord;
 use YorCreative\Scrubber\Interfaces\RegexCollectionInterface;
 use YorCreative\Scrubber\Repositories\RegexRepository;
 use YorCreative\Scrubber\SecretManager\Secret;
@@ -26,7 +27,13 @@ class ScrubberService
 
         // set datetime back to  DateTimeInterface for papertrail specifically.
         if (isset($scrubbedContent['datetime'])) {
-            $scrubbedContent['datetime'] = Carbon::parse($scrubbedContent['datetime']);
+            $datetime = match (true) {
+                is_array($scrubbedContent['datetime']) => $scrubbedContent['datetime']['date'],
+                $scrubbedContent instanceof LogRecord => Carbon::instance($scrubbedContent['datetime']),
+                default => Carbon::parse($scrubbedContent['datetime'])
+            };
+
+            $scrubbedContent['datetime'] = $datetime;
         }
 
         return $scrubbedContent;

--- a/src/Strategies/ContentProcessingStrategy/ContentProcessingStrategy.php
+++ b/src/Strategies/ContentProcessingStrategy/ContentProcessingStrategy.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace YorCreative\Scrubber\Strategies\ContentProcessingStrategy;
+
+use Illuminate\Support\Collection;
+use Monolog\LogRecord;
+use RuntimeException;
+
+class ContentProcessingStrategy
+{
+    protected Collection $handlers;
+
+    public function __construct()
+    {
+        $this->handlers = new Collection();
+    }
+
+    /**
+     * @param ProcessHandlerContract $handler
+     */
+    public function setHandler(ProcessHandlerContract $handler): void
+    {
+        $this->handlers->push($handler);
+    }
+
+    /**
+     * @param mixed $content
+     * @return string|array|LogRecord
+     */
+    public function processContent(mixed $content): string|array|LogRecord
+    {
+        $index = $this->detectHandlerIndex($content);
+
+        return is_null($index)
+            ? throw new RuntimeException('Cannot process content: ' . json_encode($content))
+            : $this->getHandlers()->get($index)->processContent($content);
+    }
+
+    /**
+     * @param mixed $content
+     * @return int|null
+     */
+    private function detectHandlerIndex(mixed $content): ?int
+    {
+        return $this->getHandlers()->search(function (ProcessHandlerContract $handler) use ($content) {
+            return $handler->canProcess($content);
+        });
+    }
+
+    /**
+     * @return Collection
+     */
+    public function getHandlers(): Collection
+    {
+        return $this->handlers;
+    }
+}

--- a/src/Strategies/ContentProcessingStrategy/ContentProcessingStrategy.php
+++ b/src/Strategies/ContentProcessingStrategy/ContentProcessingStrategy.php
@@ -15,31 +15,20 @@ class ContentProcessingStrategy
         $this->handlers = new Collection();
     }
 
-    /**
-     * @param ProcessHandlerContract $handler
-     */
     public function setHandler(ProcessHandlerContract $handler): void
     {
         $this->handlers->push($handler);
     }
 
-    /**
-     * @param mixed $content
-     * @return string|array|LogRecord
-     */
     public function processContent(mixed $content): string|array|LogRecord
     {
         $index = $this->detectHandlerIndex($content);
 
         return is_null($index)
-            ? throw new RuntimeException('Cannot process content: ' . json_encode($content))
+            ? throw new RuntimeException('Cannot process content: '.json_encode($content))
             : $this->getHandlers()->get($index)->processContent($content);
     }
 
-    /**
-     * @param mixed $content
-     * @return int|null
-     */
     private function detectHandlerIndex(mixed $content): ?int
     {
         return $this->getHandlers()->search(function (ProcessHandlerContract $handler) use ($content) {
@@ -47,9 +36,6 @@ class ContentProcessingStrategy
         });
     }
 
-    /**
-     * @return Collection
-     */
     public function getHandlers(): Collection
     {
         return $this->handlers;

--- a/src/Strategies/ContentProcessingStrategy/Handlers/ArrayContentHandler.php
+++ b/src/Strategies/ContentProcessingStrategy/Handlers/ArrayContentHandler.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace YorCreative\Scrubber\Strategies\ContentProcessingStrategy\Handlers;
+
+use Monolog\LogRecord;
+use YorCreative\Scrubber\Strategies\ContentProcessingStrategy\ProcessHandlerContract;
+use YorCreative\Scrubber\Strategies\ContentProcessingStrategy\Traits\ProcessArrayTrait;
+
+class ArrayContentHandler implements ProcessHandlerContract
+{
+    use ProcessArrayTrait;
+
+    public function canProcess(mixed $content): bool
+    {
+        return is_array($content);
+    }
+
+    public function processContent(mixed $content): string|array|LogRecord
+    {
+        return $this->processArray($content);
+    }
+}

--- a/src/Strategies/ContentProcessingStrategy/Handlers/LogRecordContentHandler.php
+++ b/src/Strategies/ContentProcessingStrategy/Handlers/LogRecordContentHandler.php
@@ -7,6 +7,7 @@ use Monolog\LogRecord;
 use YorCreative\Scrubber\Strategies\ContentProcessingStrategy\ContentProcessingStrategy;
 use YorCreative\Scrubber\Strategies\ContentProcessingStrategy\ProcessHandlerContract;
 use YorCreative\Scrubber\Strategies\ContentProcessingStrategy\Traits\ProcessArrayTrait;
+use YorCreative\Scrubber\Support\LogRecordFactory;
 
 class LogRecordContentHandler implements ProcessHandlerContract
 {
@@ -29,15 +30,13 @@ class LogRecordContentHandler implements ProcessHandlerContract
             ? []
             : app(ContentProcessingStrategy::class)->processContent($context);
 
-        $logRecord = new LogRecord(
+        return LogRecordFactory::buildRecord(
             $logRecordArr['datetime'],
             $logRecordArr['channel'],
-            Logger::toMonologLevel($logRecordArr['level']),
+            $logRecordArr['level'],
             $logRecordArr['message'],
             $logRecordArr['context'],
             $logRecordArr['extra']
         );
-
-        return $logRecord;
     }
 }

--- a/src/Strategies/ContentProcessingStrategy/Handlers/LogRecordContentHandler.php
+++ b/src/Strategies/ContentProcessingStrategy/Handlers/LogRecordContentHandler.php
@@ -2,7 +2,6 @@
 
 namespace YorCreative\Scrubber\Strategies\ContentProcessingStrategy\Handlers;
 
-use Monolog\Logger;
 use Monolog\LogRecord;
 use YorCreative\Scrubber\Strategies\ContentProcessingStrategy\ContentProcessingStrategy;
 use YorCreative\Scrubber\Strategies\ContentProcessingStrategy\ProcessHandlerContract;

--- a/src/Strategies/ContentProcessingStrategy/Handlers/LogRecordContentHandler.php
+++ b/src/Strategies/ContentProcessingStrategy/Handlers/LogRecordContentHandler.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace YorCreative\Scrubber\Strategies\ContentProcessingStrategy\Handlers;
+
+use Monolog\Logger;
+use Monolog\LogRecord;
+use YorCreative\Scrubber\Strategies\ContentProcessingStrategy\ContentProcessingStrategy;
+use YorCreative\Scrubber\Strategies\ContentProcessingStrategy\ProcessHandlerContract;
+use YorCreative\Scrubber\Strategies\ContentProcessingStrategy\Traits\ProcessArrayTrait;
+
+class LogRecordContentHandler implements ProcessHandlerContract
+{
+    use ProcessArrayTrait;
+
+    public function canProcess(mixed $content): bool
+    {
+        return $content instanceof LogRecord;
+    }
+
+    public function processContent(mixed $content): string|array|LogRecord
+    {
+        $logRecordArr = $content->toArray();
+
+        $logRecordArr['message'] = empty($message = $logRecordArr['message'])
+            ? $message
+            : app(ContentProcessingStrategy::class)->processContent($logRecordArr['message']);
+
+        $logRecordArr['context'] = empty($context = $logRecordArr['context'])
+            ? []
+            : app(ContentProcessingStrategy::class)->processContent($context);
+
+        $logRecord = new LogRecord(
+            $logRecordArr['datetime'],
+            $logRecordArr['channel'],
+            Logger::toMonologLevel($logRecordArr['level']),
+            $logRecordArr['message'],
+            $logRecordArr['context'],
+            $logRecordArr['extra']
+        );
+
+        return $logRecord;
+    }
+}

--- a/src/Strategies/ContentProcessingStrategy/Handlers/StringContentHandler.php
+++ b/src/Strategies/ContentProcessingStrategy/Handlers/StringContentHandler.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace YorCreative\Scrubber\Strategies\ContentProcessingStrategy\Handlers;
+
+use Monolog\LogRecord;
+use YorCreative\Scrubber\Services\ScrubberService;
+use YorCreative\Scrubber\Strategies\ContentProcessingStrategy\ProcessHandlerContract;
+
+class StringContentHandler implements ProcessHandlerContract
+{
+    public function canProcess(mixed $content): bool
+    {
+        return is_string($content);
+    }
+
+    public function processContent(mixed $content): string|array|LogRecord
+    {
+        ScrubberService::autoSanitize($content);
+
+        return $content;
+    }
+}

--- a/src/Strategies/ContentProcessingStrategy/ProcessHandlerContract.php
+++ b/src/Strategies/ContentProcessingStrategy/ProcessHandlerContract.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace YorCreative\Scrubber\Strategies\ContentProcessingStrategy;
+
+use Monolog\LogRecord;
+
+interface ProcessHandlerContract
+{
+    public function canProcess(mixed $content): bool;
+
+    public function processContent(mixed $content): string|array|LogRecord;
+}

--- a/src/Strategies/ContentProcessingStrategy/Traits/ProcessArrayTrait.php
+++ b/src/Strategies/ContentProcessingStrategy/Traits/ProcessArrayTrait.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace YorCreative\Scrubber\Strategies\ContentProcessingStrategy\Traits;
+
+use YorCreative\Scrubber\Services\ScrubberService;
+
+trait ProcessArrayTrait
+{
+    public function processArrayRecursively(array $content): array
+    {
+        foreach ($content as $key => $value) {
+            if (null !== $value) {
+                if (is_array($value)) {
+                    $content[$key] = $this->processArray($value);
+                } elseif (is_object($value) && ! method_exists($value, '__toString')) {
+                    $content[$key] = $this->processArray((array) $value);
+                } else {
+                    $value = (string) $value;
+
+                    ScrubberService::autoSanitize($value);
+
+                    $content[$key] =  $value;
+                }
+            }
+        }
+
+        return $content;
+    }
+
+    public function processArray(array $content): array
+    {
+        $jsonContent = ScrubberService::encodeRecord($content);
+        if ('' === $jsonContent) {
+            // failed to convert array to JSON, so process array recursively
+            return $this->processArrayRecursively($content);
+        }
+
+        ScrubberService::autoSanitize($jsonContent);
+
+        return ScrubberService::decodeRecord($jsonContent);
+    }
+}

--- a/src/Strategies/ContentProcessingStrategy/Traits/ProcessArrayTrait.php
+++ b/src/Strategies/ContentProcessingStrategy/Traits/ProcessArrayTrait.php
@@ -19,7 +19,7 @@ trait ProcessArrayTrait
 
                     ScrubberService::autoSanitize($value);
 
-                    $content[$key] =  $value;
+                    $content[$key] = $value;
                 }
             }
         }

--- a/src/Support/LogRecordFactory.php
+++ b/src/Support/LogRecordFactory.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace YorCreative\Scrubber\Support;
+
+use DateTimeImmutable;
+use InvalidArgumentException;
+use LogicException;
+use Monolog\Logger;
+use Monolog\LogRecord;
+use RuntimeException;
+
+class LogRecordFactory
+{
+    /**
+     * @param DateTimeImmutable $datetime
+     * @param string $channel
+     * @param int $level
+     * @param string $message
+     * @param array $context
+     * @param array $extra
+     * @return LogRecord
+     */
+    public static function buildRecord(DateTimeImmutable $datetime, string $channel, int $level, string $message, array $context, array $extra)
+    {
+        if (interface_exists(LogRecord::class)) {
+            return self::buildFromAnonymousLogRecord($datetime, $channel, $level, $message, $context, $extra);
+        } elseif (class_exists(LogRecord::class)) {
+            return self::buildFromLogRecordClass($datetime, $channel, $level, $message, $context, $extra);
+        } else {
+            throw new RuntimeException(' ¯\_(ツ)_/¯ ');
+        }
+    }
+
+    /**
+     * @param DateTimeImmutable $datetime
+     * @param string $channel
+     * @param int $level
+     * @param string $message
+     * @param array $context
+     * @param array $extra
+     * @return LogRecord
+     */
+    private static function buildFromAnonymousLogRecord(DateTimeImmutable $datetime, string $channel, int $level, string $message, array $context, array $extra): LogRecord
+    {
+        return new class($datetime, $channel, $level, $message, $context, $extra) implements LogRecord {
+            private const MODIFIABLE_FIELDS = [
+                'extra' => true,
+                'formatted' => true,
+            ];
+
+            public function __construct(
+                private DateTimeImmutable $datetime,
+                private string            $channel,
+                private int               $level,
+                private string            $message,
+                private array             $context,
+                private array             $extra
+            )
+            {
+                //
+            }
+
+            public function offsetSet(mixed $offset, mixed $value): void
+            {
+                if ($offset === 'extra') {
+                    if (!is_array($value)) {
+                        throw new InvalidArgumentException('extra must be an array');
+                    }
+
+                    $this->extra = $value;
+                    return;
+                }
+
+                if ($offset === 'formatted') {
+                    $this->formatted = $value;
+                    return;
+                }
+
+                throw new LogicException('Unsupported operation: setting ' . $offset);
+            }
+
+            public function offsetExists(mixed $offset): bool
+            {
+                if ($offset === 'level_name') {
+                    return true;
+                }
+
+                return isset($this->{$offset});
+            }
+
+            public function offsetUnset(mixed $offset): void
+            {
+                throw new LogicException('Unsupported operation');
+            }
+
+            public function &offsetGet(mixed $offset): mixed
+            {
+                if ($offset === 'level_name') {
+                    $offset = 'levelName';
+                }
+
+                if (isset(self::MODIFIABLE_FIELDS[$offset])) {
+                    return $this->{$offset};
+                }
+
+                // avoid returning readonly props by ref as this is illegal
+                $copy = $this->{$offset};
+
+                return $copy;
+            }
+
+            public function toArray(): array
+            {
+                return [
+                    'message' => $this->message,
+                    'context' => $this->context,
+                    'level' => $this->level,
+                    'level_name' => Logger::getLevelName($this->level),
+                    'channel' => $this->channel,
+                    'datetime' => $this->datetime,
+                    'extra' => $this->extra,
+                ];
+            }
+
+            public function with(mixed ...$args): self
+            {
+                foreach (['message', 'context', 'level', 'channel', 'datetime', 'extra'] as $prop) {
+                    $args[$prop] ??= $this->{$prop};
+                }
+
+                return new self(...$args);
+            }
+        };
+    }
+
+    /**
+     * @param DateTimeImmutable $datetime
+     * @param string $channel
+     * @param int $level
+     * @param string $message
+     * @param array $context
+     * @param array $extra
+     * @return LogRecord
+     */
+    private static function buildFromLogRecordClass(DateTimeImmutable $datetime, string $channel, int $level, string $message, array $context, array $extra): LogRecord
+    {
+        return new LogRecord(
+            $datetime,
+            $channel,
+            Logger::toMonologLevel($level),
+            $message,
+            $context,
+            $extra
+        );
+    }
+}

--- a/src/Support/LogRecordFactory.php
+++ b/src/Support/LogRecordFactory.php
@@ -12,12 +12,6 @@ use RuntimeException;
 class LogRecordFactory
 {
     /**
-     * @param DateTimeImmutable $datetime
-     * @param string $channel
-     * @param int $level
-     * @param string $message
-     * @param array $context
-     * @param array $extra
      * @return LogRecord
      */
     public static function buildRecord(DateTimeImmutable $datetime, string $channel, int $level, string $message, array $context, array $extra)
@@ -31,18 +25,10 @@ class LogRecordFactory
         }
     }
 
-    /**
-     * @param DateTimeImmutable $datetime
-     * @param string $channel
-     * @param int $level
-     * @param string $message
-     * @param array $context
-     * @param array $extra
-     * @return LogRecord
-     */
     private static function buildFromAnonymousLogRecord(DateTimeImmutable $datetime, string $channel, int $level, string $message, array $context, array $extra): LogRecord
     {
-        return new class($datetime, $channel, $level, $message, $context, $extra) implements LogRecord {
+        return new class($datetime, $channel, $level, $message, $context, $extra) implements LogRecord
+        {
             private const MODIFIABLE_FIELDS = [
                 'extra' => true,
                 'formatted' => true,
@@ -50,33 +36,34 @@ class LogRecordFactory
 
             public function __construct(
                 private DateTimeImmutable $datetime,
-                private string            $channel,
-                private int               $level,
-                private string            $message,
-                private array             $context,
-                private array             $extra
-            )
-            {
+                private string $channel,
+                private int $level,
+                private string $message,
+                private array $context,
+                private array $extra
+            ) {
                 //
             }
 
             public function offsetSet(mixed $offset, mixed $value): void
             {
                 if ($offset === 'extra') {
-                    if (!is_array($value)) {
+                    if (! is_array($value)) {
                         throw new InvalidArgumentException('extra must be an array');
                     }
 
                     $this->extra = $value;
+
                     return;
                 }
 
                 if ($offset === 'formatted') {
                     $this->formatted = $value;
+
                     return;
                 }
 
-                throw new LogicException('Unsupported operation: setting ' . $offset);
+                throw new LogicException('Unsupported operation: setting '.$offset);
             }
 
             public function offsetExists(mixed $offset): bool
@@ -133,15 +120,6 @@ class LogRecordFactory
         };
     }
 
-    /**
-     * @param DateTimeImmutable $datetime
-     * @param string $channel
-     * @param int $level
-     * @param string $message
-     * @param array $context
-     * @param array $extra
-     * @return LogRecord
-     */
     private static function buildFromLogRecordClass(DateTimeImmutable $datetime, string $channel, int $level, string $message, array $context, array $extra): LogRecord
     {
         return new LogRecord(

--- a/tests/Feature/ScrubMessageTest.php
+++ b/tests/Feature/ScrubMessageTest.php
@@ -81,21 +81,21 @@ class ScrubMessageTest extends TestCase
             'one' => $rawMessage,
             'two' => $rawMessage,
             'three' => [
-                'four' => $rawMessage
-            ]
+                'four' => $rawMessage,
+            ],
         ];
 
         $expectedContext = [
             'one' => $expectedMessage,
             'two' => $expectedMessage,
             'three' => [
-                'four' => $expectedMessage
-            ]
+                'four' => $expectedMessage,
+            ],
         ];
 
         $dateTimeImmutable = Carbon::now()->toDateTimeImmutable();
 
-        $logRecord         = $this->getTestLogRecord($dateTimeImmutable, $rawMessage, $rawContext);
+        $logRecord = $this->getTestLogRecord($dateTimeImmutable, $rawMessage, $rawContext);
         $expectedLogRecord = $this->getTestLogRecord($dateTimeImmutable, $expectedMessage, $expectedContext);
 
         $sanitizedMessage = Scrubber::processMessage($logRecord);

--- a/tests/Feature/ScrubMessageTest.php
+++ b/tests/Feature/ScrubMessageTest.php
@@ -2,6 +2,7 @@
 
 namespace YorCreative\Scrubber\Tests\Feature;
 
+use Carbon\Carbon;
 use YorCreative\Scrubber\Repositories\RegexRepository;
 use YorCreative\Scrubber\Scrubber;
 use YorCreative\Scrubber\Tests\TestCase;
@@ -62,5 +63,43 @@ class ScrubMessageTest extends TestCase
         $sanitizedMessage = Scrubber::processMessage($message);
 
         $this->assertEquals($expected, $sanitizedMessage);
+    }
+
+    public function test_it_can_process_log_record()
+    {
+        $message = 'Something something, here is the slack token {slack_token}';
+
+        $expectedMessage = str_replace('{slack_token}', config('scrubber.redaction'), $message);
+
+        $rawMessage = str_replace(
+            '{slack_token}',
+            app(RegexRepository::class)->getRegexCollection()->get('slack_token')->getTestableString(),
+            $message
+        );
+
+        $rawContext = [
+            'one' => $rawMessage,
+            'two' => $rawMessage,
+            'three' => [
+                'four' => $rawMessage
+            ]
+        ];
+
+        $expectedContext = [
+            'one' => $expectedMessage,
+            'two' => $expectedMessage,
+            'three' => [
+                'four' => $expectedMessage
+            ]
+        ];
+
+        $dateTimeImmutable = Carbon::now()->toDateTimeImmutable();
+
+        $logRecord         = $this->getTestLogRecord($dateTimeImmutable, $rawMessage, $rawContext);
+        $expectedLogRecord = $this->getTestLogRecord($dateTimeImmutable, $expectedMessage, $expectedContext);
+
+        $sanitizedMessage = Scrubber::processMessage($logRecord);
+
+        $this->assertEquals($expectedLogRecord, $sanitizedMessage);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,7 +2,6 @@
 
 namespace YorCreative\Scrubber\Tests;
 
-use Carbon\Carbon;
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
@@ -70,5 +69,4 @@ class TestCase extends \Orchestra\Testbench\TestCase
 
         return new LogRecord($datetime, $channel, Logger::toMonologLevel($level), $message, $context, $extra);
     }
-
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,10 +2,13 @@
 
 namespace YorCreative\Scrubber\Tests;
 
+use Carbon\Carbon;
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
 use Illuminate\Support\Str;
+use Monolog\Logger;
+use Monolog\LogRecord;
 use YorCreative\Scrubber\Clients\GitLabClient;
 use YorCreative\Scrubber\ScrubberServiceProvider;
 
@@ -58,4 +61,14 @@ class TestCase extends \Orchestra\Testbench\TestCase
 
         return file_get_contents(__DIR__.'/Mocks/'.$filename);
     }
+
+    protected function getTestLogRecord(\DateTimeImmutable $datetime, string $message, array $context): LogRecord
+    {
+        $channel = 'test_channel';
+        $level = 200;
+        $extra = [];
+
+        return new LogRecord($datetime, $channel, Logger::toMonologLevel($level), $message, $context, $extra);
+    }
+
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,7 +6,6 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
 use Illuminate\Support\Str;
-use Monolog\Logger;
 use Monolog\LogRecord;
 use YorCreative\Scrubber\Clients\GitLabClient;
 use YorCreative\Scrubber\ScrubberServiceProvider;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -10,6 +10,7 @@ use Monolog\Logger;
 use Monolog\LogRecord;
 use YorCreative\Scrubber\Clients\GitLabClient;
 use YorCreative\Scrubber\ScrubberServiceProvider;
+use YorCreative\Scrubber\Support\LogRecordFactory;
 
 class TestCase extends \Orchestra\Testbench\TestCase
 {
@@ -67,6 +68,6 @@ class TestCase extends \Orchestra\Testbench\TestCase
         $level = 200;
         $extra = [];
 
-        return new LogRecord($datetime, $channel, Logger::toMonologLevel($level), $message, $context, $extra);
+        return LogRecordFactory::buildRecord($datetime, $channel, $level, $message, $context, $extra);
     }
 }

--- a/tests/Unit/Repositories/RegexRepositoryTest.php
+++ b/tests/Unit/Repositories/RegexRepositoryTest.php
@@ -39,8 +39,8 @@ class RegexRepositoryTest extends TestCase
         $hits = 0;
 
         $content = app(RegexRepository::class)->getRegexCollection()->get('google_api')->getTestableString()
-            . ' something something something '
-            . app(RegexRepository::class)->getRegexCollection()->get('google_api')->getTestableString();
+            .' something something something '
+            .app(RegexRepository::class)->getRegexCollection()->get('google_api')->getTestableString();
 
         $this->assertStringContainsString(
             config('scrubber.redaction'),
@@ -74,8 +74,8 @@ class RegexRepositoryTest extends TestCase
     public function it_can_check_hits()
     {
         $content = app(RegexRepository::class)->getRegexCollection()->get('google_api')->getTestableString()
-            . ' something something something '
-            . app(RegexRepository::class)->getRegexCollection()->get('google_api')->getTestableString();
+            .' something something something '
+            .app(RegexRepository::class)->getRegexCollection()->get('google_api')->getTestableString();
 
         $hits = app(RegexRepository::class)->check(
             app(RegexRepository::class)->getRegexCollection()->get('google_api')->getPattern(),

--- a/tests/Unit/Repositories/RegexRepositoryTest.php
+++ b/tests/Unit/Repositories/RegexRepositoryTest.php
@@ -39,8 +39,8 @@ class RegexRepositoryTest extends TestCase
         $hits = 0;
 
         $content = app(RegexRepository::class)->getRegexCollection()->get('google_api')->getTestableString()
-            .' something something something '
-            .app(RegexRepository::class)->getRegexCollection()->get('google_api')->getTestableString();
+            . ' something something something '
+            . app(RegexRepository::class)->getRegexCollection()->get('google_api')->getTestableString();
 
         $this->assertStringContainsString(
             config('scrubber.redaction'),
@@ -63,5 +63,25 @@ class RegexRepositoryTest extends TestCase
     public function it_can_receive_a_collection()
     {
         $this->assertInstanceOf(Collection::class, app(RegexRepository::class)->getRegexCollection());
+    }
+
+    /**
+     * @test
+     *
+     * @group RegexRepository
+     * @group Unit
+     */
+    public function it_can_check_hits()
+    {
+        $content = app(RegexRepository::class)->getRegexCollection()->get('google_api')->getTestableString()
+            . ' something something something '
+            . app(RegexRepository::class)->getRegexCollection()->get('google_api')->getTestableString();
+
+        $hits = app(RegexRepository::class)->check(
+            app(RegexRepository::class)->getRegexCollection()->get('google_api')->getPattern(),
+            $content
+        );
+
+        $this->assertEquals(2, $hits);
     }
 }

--- a/tests/Unit/Services/ScrubberServiceTest.php
+++ b/tests/Unit/Services/ScrubberServiceTest.php
@@ -60,4 +60,9 @@ class ScrubberServiceTest extends TestCase
 
         $this->assertStringContainsString(config('scrubber.redaction'), $content);
     }
+
+    public function test_it_can_get_regex_repository()
+    {
+        $this->assertInstanceOf(RegexRepository::class, ScrubberService::getRegexRepository());
+    }
 }

--- a/tests/Unit/Strategies/ContentProcessingStrategyTest.php
+++ b/tests/Unit/Strategies/ContentProcessingStrategyTest.php
@@ -2,9 +2,9 @@
 
 namespace YorCreative\Scrubber\Test\Unit\Strategies;
 
+use YorCreative\Scrubber\Strategies\ContentProcessingStrategy\ContentProcessingStrategy;
 use YorCreative\Scrubber\Strategies\ContentProcessingStrategy\Handlers\StringContentHandler;
 use YorCreative\Scrubber\Tests\TestCase;
-use YorCreative\Scrubber\Strategies\ContentProcessingStrategy\ContentProcessingStrategy;
 
 class ContentProcessingStrategyTest extends TestCase
 {
@@ -29,7 +29,7 @@ class ContentProcessingStrategyTest extends TestCase
         $reflectedStrategy->setAccessible(true);
 
         $index = $reflectedStrategy->invokeArgs($this->strategy, [
-            'string content'
+            'string content',
         ]);
 
         $this->assertEquals(0, $index);

--- a/tests/Unit/Strategies/ContentProcessingStrategyTest.php
+++ b/tests/Unit/Strategies/ContentProcessingStrategyTest.php
@@ -2,8 +2,13 @@
 
 namespace YorCreative\Scrubber\Test\Unit\Strategies;
 
+use Carbon\Carbon;
+use Monolog\Logger;
 use YorCreative\Scrubber\Strategies\ContentProcessingStrategy\ContentProcessingStrategy;
+use YorCreative\Scrubber\Strategies\ContentProcessingStrategy\Handlers\ArrayContentHandler;
+use YorCreative\Scrubber\Strategies\ContentProcessingStrategy\Handlers\LogRecordContentHandler;
 use YorCreative\Scrubber\Strategies\ContentProcessingStrategy\Handlers\StringContentHandler;
+use YorCreative\Scrubber\Support\LogRecordFactory;
 use YorCreative\Scrubber\Tests\TestCase;
 
 class ContentProcessingStrategyTest extends TestCase
@@ -35,5 +40,43 @@ class ContentProcessingStrategyTest extends TestCase
         $this->assertEquals(0, $index);
 
         $this->assertInstanceOf(StringContentHandler::class, $this->strategy->getHandlers()->get($index));
+    }
+
+    public function test_it_can_process_array_content()
+    {
+        $reflectedStrategy = new \ReflectionMethod(ContentProcessingStrategy::class, 'detectHandlerIndex');
+
+        $reflectedStrategy->setAccessible(true);
+
+        $index = $reflectedStrategy->invokeArgs($this->strategy, [
+            ['key' => 'value'],
+        ]);
+
+        $this->assertEquals(1, $index);
+
+        $this->assertInstanceOf(ArrayContentHandler::class, $this->strategy->getHandlers()->get($index));
+    }
+
+
+    public function test_it_can_process_log_record()
+    {
+        $reflectedStrategy = new \ReflectionMethod(ContentProcessingStrategy::class, 'detectHandlerIndex');
+
+        $reflectedStrategy->setAccessible(true);
+
+        $index = $reflectedStrategy->invokeArgs($this->strategy, [
+            LogRecordFactory::buildRecord(
+                Carbon::now()->toDateTimeImmutable(),
+                'test_channel',
+                200,
+                'just_a_test',
+                [],
+                []
+            ),
+        ]);
+
+        $this->assertEquals(2, $index);
+
+        $this->assertInstanceOf(LogRecordContentHandler::class, $this->strategy->getHandlers()->get($index));
     }
 }

--- a/tests/Unit/Strategies/ContentProcessingStrategyTest.php
+++ b/tests/Unit/Strategies/ContentProcessingStrategyTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace YorCreative\Scrubber\Test\Unit\Strategies;
+
+use YorCreative\Scrubber\Strategies\ContentProcessingStrategy\Handlers\StringContentHandler;
+use YorCreative\Scrubber\Tests\TestCase;
+use YorCreative\Scrubber\Strategies\ContentProcessingStrategy\ContentProcessingStrategy;
+
+class ContentProcessingStrategyTest extends TestCase
+{
+    protected ContentProcessingStrategy $strategy;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->strategy = $this->app->get(ContentProcessingStrategy::class);
+    }
+
+    public function test_it_has_processing_handlers_loaded()
+    {
+        $this->assertCount(3, $this->strategy->getHandlers());
+    }
+
+    public function test_it_can_process_string_content()
+    {
+        $reflectedStrategy = new \ReflectionMethod(ContentProcessingStrategy::class, 'detectHandlerIndex');
+
+        $reflectedStrategy->setAccessible(true);
+
+        $index = $reflectedStrategy->invokeArgs($this->strategy, [
+            'string content'
+        ]);
+
+        $this->assertEquals(0, $index);
+
+        $this->assertInstanceOf(StringContentHandler::class, $this->strategy->getHandlers()->get($index));
+    }
+}


### PR DESCRIPTION
## Change Overview

* Introduces LogRecordFactory class to which allows a Log Record to be built differently depending on mongolog version that host laravel application is running. 
* Introduces ContentProcessingStrategy as a Singleton to manage diverse content handlers
* Implements StringContentHandler, ArrayContentHandler, and LogRecordContentHandler and register them with ContentProcessingStrategy singleton
* Enhance test coverage for ContentProcessingStrategy & ScrubMessageTest
* Updates Composer to upgrade to v3 mongolog for Illuminate\Contracts v10
* Updates to Composer to sustain support for to v2 mongolog for Illuminate\Contracts v9
* Exposes the regex repository through scrubber service to scrubber class.
* Bug fixes
* Remove support for illuminate\contracts 8
* Updates README credit adding @majchrosoft && @lucaxue 🖖🏼 🖖🏼 🙏🏼 👏🏼 