### PR TITLE
Add pattern exclusion support for wildcard regex loading

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,18 @@
-FROM php:8.3-fpm
+FROM php:8.4-fpm
 
 RUN apt-get update \
-    && apt-get -y install libzip-dev zlib1g-dev git zip unzip libicu-dev g++ libbz2-dev libmemcached-dev \
+    && apt-get -y install libzip-dev zlib1g-dev git zip unzip libicu-dev \
     && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/* \
 
-RUN docker-php-ext-configure zip && docker-php-ext-install pdo pdo_mysql zip bz2 intl
+RUN docker-php-ext-configure zip && docker-php-ext-install zip intl
+
+# Install Xdebug only
+RUN pecl install xdebug \
+    && docker-php-ext-enable xdebug
+
+# Optional: Add Xdebug config (adjust path if needed)
+COPY ./xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini
+
 
 # Get latest Composer
 COPY --from=composer:latest /usr/bin/composer /usr/bin/composer

--- a/README.md
+++ b/README.md
@@ -345,9 +345,13 @@ composer test
 ## Credits
 
 - [Yorda](https://github.com/yordadev)
+- [Magentron](https://github.com/Magentron)
 - [Whizboy-Arnold](https://github.com/Whizboy-Arnold)
 - [majchrosoft](https://github.com/majchrosoft)
 - [Lucaxue](https://github.com/lucaxue)
 - [AlexGodbehere](https://github.com/AlexGodbehere)
+- [JorgeAnzola](https://github.com/JorgeAnzola)
+- [Haddowg](https://github.com/haddowg)
+- [LorenzoSapora](https://github.com/LorenzoSapora)
 - [All Contributors](../../contributors)
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,27 @@ return [
      * which will then search the `custom_regex_namespaces` and the default core regexes for a match.
      */
     'regex_loader' => ['*'],
+    
+    /**
+     * Specify regex patterns to exclude from loading when using the regex loader
+     * This allows fine-grained control over which regex patterns are loaded, especially useful when using wildcard (*) in regex_loader
+     * 
+     * You can exclude patterns using any of these formats:
+     * - Fully qualified class name (e.g., 'YorCreative\Scrubber\RegexCollection\GoogleApi')
+     * - Base class name (e.g., 'GoogleApi', 'EmailAddress')
+     * - Pattern constant from RegexCollection (e.g., RegexCollection::$GOOGLE_API)
+     * - Custom namespace class (e.g., 'App\Scrubber\RegexCollection\HerokuApiKey')
+     * 
+     * Example:
+     * [
+     *     'GoogleApi',
+     *     'YorCreative\Scrubber\RegexCollection\EmailAddress',
+     *     RegexCollection::$HEROKU_API_KEY,
+     *     'App\Scrubber\RegexCollection\HerokuApiKey'
+     * ]
+     */
+    'exclude_regex' => [],
+
 
     /**
      * Specify namespaces from which regexes will be loaded when using the wildcard (*)
@@ -257,6 +278,34 @@ The `regex_loader` array should be defined as such:
         'TestRegex'
     ],
 ```
+### RegexCollection & Defining Opt-out
+
+When using wildcard loading (`'regex_loader' => ['*']`), you can exclude specific regex patterns using the `exclude_regex` configuration. This allows you to load all patterns except those explicitly excluded.
+
+```php
+'exclude_regex' => [
+    // Exclude by base class name
+    'GoogleApi',
+    
+    // Exclude by fully qualified class name
+    'YorCreative\Scrubber\RegexCollection\EmailAddress',
+    
+    // Exclude using RegexCollection constant
+    RegexCollection::$HEROKU_API_KEY,
+    
+    // Exclude from custom namespace
+    'App\Scrubber\RegexCollection\HerokuApiKey'
+],
+```
+
+The exclude_regex configuration supports multiple formats for excluding patterns:
+- Base class names (e.g., 'GoogleApi')
+- Fully qualified class names
+- RegexCollection constants
+- Custom namespace classes
+
+This is particularly useful when you want to use most patterns but need to exclude a few specific ones from your scrubbing process.
+
 
 ## About the Scrubber
 

--- a/config/scrubber.php
+++ b/config/scrubber.php
@@ -37,6 +37,26 @@ return [
     'regex_loader' => ['*'],
 
     /**
+     * Specify regex patterns to exclude from loading when using the regex loader
+     * This allows fine-grained control over which regex patterns are loaded, especially useful when using wildcard (*) in regex_loader
+     *
+     * You can exclude patterns using any of these formats:
+     * - Fully qualified class name (e.g., 'YorCreative\Scrubber\RegexCollection\GoogleApi')
+     * - Base class name (e.g., 'GoogleApi', 'EmailAddress')
+     * - Pattern constant from RegexCollection (e.g., RegexCollection::$GOOGLE_API)
+     * - Custom namespace class (e.g., 'App\Scrubber\RegexCollection\HerokuApiKey')
+     *
+     * Example:
+     * [
+     *     'GoogleApi',
+     *     'YorCreative\Scrubber\RegexCollection\EmailAddress',
+     *     RegexCollection::$HEROKU_API_KEY,
+     *     'App\Scrubber\RegexCollection\HerokuApiKey'
+     * ]
+     */
+    'exclude_regex' => [],
+
+    /**
      * Specify namespaces from which regexes will be loaded when using the wildcard (*)
      * for the regex_loader or where you use unqualified class names.
      */

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -26,6 +26,9 @@
     </include>
     <exclude>
       <directory suffix=".php">./src/Handlers</directory>
+      <directory suffix=".php">./src/Exceptions</directory>
+      <directory suffix=".php">./src/Commands</directory>
+      <directory suffix=".php">./src/Interfaces</directory>
     </exclude>
   </source>
 </phpunit>

--- a/src/Strategies/RegexLoader/Loaders/WildcardRegex.php
+++ b/src/Strategies/RegexLoader/Loaders/WildcardRegex.php
@@ -46,13 +46,12 @@ class WildcardRegex extends NamespaceLoader
         $regexCollectionArray = $reflection->getStaticProperties();
 
         return array_map(function ($class) use ($regexCollectionArray) {
-
-            $regexPattern = array_find($regexCollectionArray, function ($regex) use ($class) {
+            $regexPatterns = array_filter($regexCollectionArray, function ($regex) use ($class) {
                 return $regex === $class;
             });
 
-            if ($regexPattern) {
-                return "YorCreative\\Scrubber\\RegexCollection\\$regexPattern";
+            if (!empty($regexPatterns)) {
+                return "YorCreative\\Scrubber\\RegexCollection\\$class";
             }
 
             // If the class is unqualified, attempt to resolve within custom namespaces

--- a/src/Strategies/RegexLoader/Loaders/WildcardRegex.php
+++ b/src/Strategies/RegexLoader/Loaders/WildcardRegex.php
@@ -5,28 +5,67 @@ namespace YorCreative\Scrubber\Strategies\RegexLoader\Loaders;
 use HaydenPierce\ClassFinder\ClassFinder;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Config;
+use ReflectionClass;
+use YorCreative\Scrubber\Repositories\RegexCollection;
 
 class WildcardRegex extends NamespaceLoader
 {
+    protected const CONFIG_REGEX_LOADER = 'scrubber.regex_loader';
+
+    protected const CONFIG_EXCLUDE_REGEX = 'scrubber.exclude_regex';
+
     public function canLoad(): bool
     {
-        return in_array('*', Config::get('scrubber.regex_loader'));
+        return in_array('*', Config::get(self::CONFIG_REGEX_LOADER, []), true);
     }
 
     public function load(Collection &$regexCollection): void
     {
-        foreach ($this->getNamespaces() as $namespace) {
+        // Get excluded classes and resolve RegexCollection static properties
+        $excludedClasses = $this->resolveExcludedClasses(Config::get(self::CONFIG_EXCLUDE_REGEX, []));
 
-            foreach ($this->getRegexClassesInNamespace($namespace) as $fullyQualifiedClassName) {
-                $this->loadRegex($fullyQualifiedClassName, $regexCollection);
+        foreach ($this->getNamespaces() as $namespace) {
+            $classes = $this->getRegexClassesInNamespace($namespace, $excludedClasses);
+            foreach ($classes as $class) {
+                $this->loadRegex($class, $regexCollection);
             }
         }
     }
 
-    protected function getRegexClassesInNamespace(string $namespace): array
+    protected function getRegexClassesInNamespace(string $namespace, array $excludedClasses): array
     {
-        return Collection::make(ClassFinder::getClassesInNamespace($namespace))
-            ->filter(fn ($class) => $this->isRegexClass($class))
-            ->toArray();
+        return array_filter(
+            ClassFinder::getClassesInNamespace($namespace),
+            fn (string $class): bool => $this->isRegexClass($class) && ! in_array($class, $excludedClasses, true)
+        );
+    }
+
+    protected function resolveExcludedClasses(array $excludedClasses): array
+    {
+        $reflection = new ReflectionClass('YorCreative\Scrubber\Repositories\RegexCollection');
+        $regexCollectionArray = $reflection->getStaticProperties();
+
+        return array_map(function ($class) use ($regexCollectionArray) {
+
+            $regexPattern = array_find($regexCollectionArray, function ($regex) use ($class) {
+                return $regex === $class;
+            });
+
+            if ($regexPattern) {
+                return "YorCreative\\Scrubber\\RegexCollection\\$regexPattern";
+            }
+
+            // If the class is unqualified, attempt to resolve within custom namespaces
+            if (strpos($class, '\\') === false) {
+                foreach ($this->getNamespaces() as $namespace) {
+                    $potentialClass = $namespace.'\\'.$class;
+                    if (class_exists($potentialClass)) {
+                        return $potentialClass;
+                    }
+                }
+            }
+
+            return $class;
+        }, $excludedClasses);
     }
 }

--- a/src/Strategies/RegexLoader/Loaders/WildcardRegex.php
+++ b/src/Strategies/RegexLoader/Loaders/WildcardRegex.php
@@ -50,7 +50,7 @@ class WildcardRegex extends NamespaceLoader
                 return $regex === $class;
             });
 
-            if (!empty($regexPatterns)) {
+            if (! empty($regexPatterns)) {
                 return "YorCreative\\Scrubber\\RegexCollection\\$class";
             }
 

--- a/tests/Feature/ScrubLogTest.php
+++ b/tests/Feature/ScrubLogTest.php
@@ -7,6 +7,8 @@ use YorCreative\Scrubber\Repositories\RegexRepository;
 use YorCreative\Scrubber\Scrubber;
 use YorCreative\Scrubber\Tests\TestCase;
 
+#[Group('RegexRepository')]
+#[Group('Feature')]
 class ScrubLogTest extends TestCase
 {
     private array $expectedRecord;
@@ -27,7 +29,6 @@ class ScrubLogTest extends TestCase
         ];
     }
 
-    #[Group('Feature')]
     public function test_it_can_detect_a_single_piece_of_sensitive_information_and_scrub_the_log()
     {
         $this->expectedRecord = array_merge($this->expectedRecord['context'], [
@@ -57,7 +58,6 @@ class ScrubLogTest extends TestCase
         $this->assertEquals($this->expectedRecord, $sanitizedRecord);
     }
 
-    #[Group('Feature')]
     public function test_it_can_detect_multiple_sensitive_information_and_scrub_the_log()
     {
         $this->expectedRecord = array_merge($this->expectedRecord['context'], [
@@ -97,7 +97,6 @@ class ScrubLogTest extends TestCase
         $this->assertEquals($this->expectedRecord, $sanitizedRecord);
     }
 
-    #[Group('Feature')]
     public function test_it_can_binary_detect_multiple_sensitive_information_and_scrub_the_log()
     {
         $binary = hex2bin('eb13cd61f3e640d1b913eefbb93bd838');
@@ -141,7 +140,6 @@ class ScrubLogTest extends TestCase
         $this->assertEquals($this->expectedRecord, $sanitizedRecord);
     }
 
-    #[Group('Feature')]
     public function test_it_can_handle_binary_objects()
     {
         $object = new \stdClass;
@@ -161,7 +159,6 @@ class ScrubLogTest extends TestCase
         $this->assertEquals($this->expectedRecord, $sanitizedRecord);
     }
 
-    #[Group('Feature')]
     public function test_it_can_handle_resources()
     {
         $resource = fopen('/dev/null', 'r');

--- a/tests/Feature/ScrubMessageTest.php
+++ b/tests/Feature/ScrubMessageTest.php
@@ -8,9 +8,11 @@ use YorCreative\Scrubber\Repositories\RegexRepository;
 use YorCreative\Scrubber\Scrubber;
 use YorCreative\Scrubber\Tests\TestCase;
 
+#[Group('RegexRepository')]
+#[Group('LogRecord')]
+#[Group('Feature')]
 class ScrubMessageTest extends TestCase
 {
-    #[Group('Feature')]
     public function test_it_can_detect_a_single_piece_of_sensitive_data_and_sanitize_it()
     {
         $message = 'Something something, here is the slack token {slack_token}';
@@ -28,7 +30,6 @@ class ScrubMessageTest extends TestCase
         $this->assertEquals($expected, $sanitizedMessage);
     }
 
-    #[Group('Feature')]
     public function test_it_can_detect_a_multiple_pieces_of_sensitive_data_and_sanitize_them()
     {
         $message = 'here is the slack token {slack_token} and the google api token {google_api}';

--- a/tests/Unit/Repositories/RegexCollectionTest.php
+++ b/tests/Unit/Repositories/RegexCollectionTest.php
@@ -3,15 +3,16 @@
 namespace YorCreative\Scrubber\Tests\Unit\Repositories;
 
 use Illuminate\Support\Collection;
+use PHPUnit\Framework\Attributes\Group;
 use ReflectionClass;
 use YorCreative\Scrubber\Repositories\RegexCollection;
 use YorCreative\Scrubber\Repositories\RegexRepository;
 use YorCreative\Scrubber\Tests\TestCase;
 
+#[Group('RegexRepository')]
+#[Group('Unit')]
 class RegexCollectionTest extends TestCase
 {
-    #[Group('RegexRepository')]
-    #[Group('Unit')]
     public function test_it_can_verify_that_every_regex_class_available_is_a_static_property_on_regex_collection()
     {
         $class = new ReflectionClass(RegexCollection::class);

--- a/tests/Unit/Repositories/RegexRepositoryTest.php
+++ b/tests/Unit/Repositories/RegexRepositoryTest.php
@@ -3,13 +3,14 @@
 namespace YorCreative\Scrubber\Tests\Unit\Repositories;
 
 use Illuminate\Support\Collection;
+use PHPUnit\Framework\Attributes\Group;
 use YorCreative\Scrubber\Repositories\RegexRepository;
 use YorCreative\Scrubber\Tests\TestCase;
 
+#[Group('RegexRepository')]
+#[Group('Unit')]
 class RegexRepositoryTest extends TestCase
 {
-    #[Group('RegexRepository')]
-    #[Group('Unit')]
     public function test_it_can_verify_that_all_regex_patterns_have_testable_counter_parts()
     {
         app(RegexRepository::class)->getRegexCollection()->each(function ($regexClass) {
@@ -24,8 +25,6 @@ class RegexRepositoryTest extends TestCase
         });
     }
 
-    #[Group('RegexRepository')]
-    #[Group('Unit')]
     public function test_it_can_sanitize_a_string_with_multiple_sensitive_pieces()
     {
         $hits = 0;
@@ -47,15 +46,11 @@ class RegexRepositoryTest extends TestCase
         $this->assertEquals(2, $hits);
     }
 
-    #[Group('RegexRepository')]
-    #[Group('Unit')]
     public function test_it_can_receive_a_collection()
     {
         $this->assertInstanceOf(Collection::class, app(RegexRepository::class)->getRegexCollection());
     }
 
-    #[Group('RegexRepository')]
-    #[Group('Unit')]
     public function test_it_can_check_hits()
     {
         $content = app(RegexRepository::class)->getRegexCollection()->get('google_api')->getTestableString()

--- a/tests/Unit/Services/ScrubberServiceTest.php
+++ b/tests/Unit/Services/ScrubberServiceTest.php
@@ -2,6 +2,7 @@
 
 namespace YorCreative\Scrubber\Tests\Unit\Services;
 
+use PHPUnit\Framework\Attributes\Group;
 use YorCreative\Scrubber\Interfaces\RegexCollectionInterface;
 use YorCreative\Scrubber\Repositories\RegexRepository;
 use YorCreative\Scrubber\Services\ScrubberService;

--- a/tests/Unit/Services/SecretServiceTest.php
+++ b/tests/Unit/Services/SecretServiceTest.php
@@ -2,11 +2,14 @@
 
 namespace YorCreative\Scrubber\Tests\Unit\Services;
 
+use PHPUnit\Framework\Attributes\Group;
 use YorCreative\Scrubber\SecretManager\Providers\Gitlab;
 use YorCreative\Scrubber\SecretManager\Secret;
 use YorCreative\Scrubber\SecretManager\SecretManager;
 use YorCreative\Scrubber\Tests\TestCase;
 
+#[Group('SecretService')]
+#[Group('Unit')]
 class SecretServiceTest extends TestCase
 {
     public function test_it_can_load_secrets_from_gitlab()

--- a/tests/Unit/Strategies/ContentProcessingStrategyTest.php
+++ b/tests/Unit/Strategies/ContentProcessingStrategyTest.php
@@ -3,6 +3,7 @@
 namespace YorCreative\Scrubber\Tests\Unit\Strategies;
 
 use Carbon\Carbon;
+use PHPUnit\Framework\Attributes\Group;
 use YorCreative\Scrubber\Strategies\ContentProcessingStrategy\ContentProcessingStrategy;
 use YorCreative\Scrubber\Strategies\ContentProcessingStrategy\Handlers\ArrayContentHandler;
 use YorCreative\Scrubber\Strategies\ContentProcessingStrategy\Handlers\LogRecordContentHandler;
@@ -10,6 +11,8 @@ use YorCreative\Scrubber\Strategies\ContentProcessingStrategy\Handlers\StringCon
 use YorCreative\Scrubber\Support\LogRecordFactory;
 use YorCreative\Scrubber\Tests\TestCase;
 
+#[Group('Strategy')]
+#[Group('Unit')]
 class ContentProcessingStrategyTest extends TestCase
 {
     protected ContentProcessingStrategy $strategy;

--- a/tests/Unit/Strategies/RegexLoaderStrategyTest.php
+++ b/tests/Unit/Strategies/RegexLoaderStrategyTest.php
@@ -87,6 +87,7 @@ class RegexLoaderStrategyTest extends TestCase
     {
         Config::set('scrubber.regex_loader', ['*']);
         Config::set('scrubber.exclude_regex', [RegexCollection::$HEROKU_API_KEY]);
+        Config::set('scrubber.custom_regex_namespaces', ['YorCreative\\Scrubber\\Tests\\Unit\\Fixtures']);
         $this->assertCount(26, app(RegexLoaderStrategy::class)->load());
     }
 

--- a/tests/Unit/Strategies/RegexLoaderStrategyTest.php
+++ b/tests/Unit/Strategies/RegexLoaderStrategyTest.php
@@ -3,6 +3,7 @@
 namespace YorCreative\Scrubber\Tests\Unit\Strategies;
 
 use Illuminate\Support\Facades\Config;
+use PHPUnit\Framework\Attributes\Group;
 use YorCreative\Scrubber\Interfaces\RegexCollectionInterface;
 use YorCreative\Scrubber\RegexCollection\GoogleApi;
 use YorCreative\Scrubber\Repositories\RegexCollection;
@@ -10,6 +11,8 @@ use YorCreative\Scrubber\Strategies\RegexLoader\RegexLoaderStrategy;
 use YorCreative\Scrubber\Tests\TestCase;
 use YorCreative\Scrubber\Tests\Unit\Fixtures\CustomRegex;
 
+#[Group('Strategy')]
+#[Group('Unit')]
 class RegexLoaderStrategyTest extends TestCase
 {
     protected function setUp(): void
@@ -19,34 +22,24 @@ class RegexLoaderStrategyTest extends TestCase
         Config::set('scrubber.regex_loader', []);
     }
 
-    #[Group('Strategy')]
-    #[Group('Unit')]
     public function test_it_can_load_default_core()
     {
         Config::set('scrubber.regex_loader', ['*']);
         $this->assertCount(26, app(RegexLoaderStrategy::class)->load());
     }
 
-    #[Group('Strategy')]
-    #[Group('Unit')]
     public function test_it_can_load_specific_core()
     {
         Config::set('scrubber.regex_loader', [RegexCollection::$GOOGLE_API]);
-
         $this->assertCount(1, app(RegexLoaderStrategy::class)->load());
     }
 
-    #[Group('Strategy')]
-    #[Group('Unit')]
     public function test_it_can_load_specific_core_by_namespace()
     {
         Config::set('scrubber.regex_loader', [GoogleApi::class]);
-
         $this->assertCount(1, app(RegexLoaderStrategy::class)->load());
     }
 
-    #[Group('Strategy')]
-    #[Group('Unit')]
     public function test_it_can_load_specific_extended_regex()
     {
         Config::set('scrubber.regex_loader', ['CustomRegex']);
@@ -54,8 +47,6 @@ class RegexLoaderStrategyTest extends TestCase
         $this->assertCount(1, app(RegexLoaderStrategy::class)->load());
     }
 
-    #[Group('Strategy')]
-    #[Group('Unit')]
     public function test_it_can_load_specific_regex_from_core_and_extended()
     {
         Config::set('scrubber.regex_loader', [RegexCollection::$GOOGLE_API, CustomRegex::class]);
@@ -63,8 +54,6 @@ class RegexLoaderStrategyTest extends TestCase
         $this->assertCount(2, app(RegexLoaderStrategy::class)->load());
     }
 
-    #[Group('Strategy')]
-    #[Group('Unit')]
     public function test_it_can_load_specific_extended_regex_by_namespace()
     {
         Config::set('scrubber.regex_loader', [CustomRegex::class]);
@@ -72,8 +61,6 @@ class RegexLoaderStrategyTest extends TestCase
         $this->assertCount(1, app(RegexLoaderStrategy::class)->load());
     }
 
-    #[Group('Strategy')]
-    #[Group('Unit')]
     public function test_it_can_load_wildcard_extended_regex()
     {
         Config::set('scrubber.regex_loader', ['*']);
@@ -81,8 +68,6 @@ class RegexLoaderStrategyTest extends TestCase
         $this->assertCount(27, app(RegexLoaderStrategy::class)->load());
     }
 
-    #[Group('Strategy')]
-    #[Group('Unit')]
     public function test_it_can_load_wildcard_extended_regex_with_excluded_regex()
     {
         Config::set('scrubber.regex_loader', ['*']);
@@ -102,8 +87,6 @@ class RegexLoaderStrategyTest extends TestCase
         $this->assertEquals('super_secret', $regex->getPattern());
     }
 
-    #[Group('Strategy')]
-    #[Group('Unit')]
     public function test_it_can_load_config_via_key_with_wildcard()
     {
         Config::set('scrubber.config_loader', ['app.secrets.*']);
@@ -117,7 +100,6 @@ class RegexLoaderStrategyTest extends TestCase
         $this->assertEquals('super_third_secret', $regexCollection->get('config::app.secrets.nested.my_secret')->getPattern());
 
         Config::set('scrubber.config_loader', ['*secret']);
-
         $regexCollection = app(RegexLoaderStrategy::class)->load();
         $this->assertCount(3, $regexCollection);
         $this->assertEquals('super_secret', $regexCollection->get('config::app.secrets.my_secret')->getPattern());
@@ -125,8 +107,6 @@ class RegexLoaderStrategyTest extends TestCase
         $this->assertEquals('super_third_secret', $regexCollection->get('config::app.secrets.nested.my_secret')->getPattern());
     }
 
-    #[Group('Strategy')]
-    #[Group('Unit')]
     public function test_it_escapes_config_values_for_regex()
     {
         Config::set('scrubber.config_loader', ['app.my_secret']);

--- a/tests/Unit/Strategies/TapLoaderStrategyTest.php
+++ b/tests/Unit/Strategies/TapLoaderStrategyTest.php
@@ -2,13 +2,14 @@
 
 namespace YorCreative\Scrubber\Tests\Unit\Strategies;
 
+use PHPUnit\Framework\Attributes\Group;
 use YorCreative\Scrubber\Strategies\TapLoader\TapLoaderStrategy;
 use YorCreative\Scrubber\Tests\TestCase;
 
+#[Group('Strategy')]
+#[Group('Unit')]
 class TapLoaderStrategyTest extends TestCase
 {
-    #[Group('Strategy')]
-    #[Group('Unit')]
     public function test_it_can_load_wildcard_channels_and_tap()
     {
         $config = app()->make('config');
@@ -22,8 +23,6 @@ class TapLoaderStrategyTest extends TestCase
         }
     }
 
-    #[Group('Strategy')]
-    #[Group('Unit')]
     public function test_it_can_load_specific_channel_and_tap()
     {
         $config = app()->make('config');
@@ -36,8 +35,6 @@ class TapLoaderStrategyTest extends TestCase
         $this->assertArrayNotHasKey('tap', $config->get('logging.channels.papertrail'));
     }
 
-    #[Group('Strategy')]
-    #[Group('Unit')]
     public function test_it_can_load_multiple_channels_and_tap()
     {
         $config = app()->make('config');

--- a/tests/Unit/Support/LogRecordFactoryTest.php
+++ b/tests/Unit/Support/LogRecordFactoryTest.php
@@ -3,9 +3,12 @@
 namespace YorCreative\Scrubber\Tests\Unit\Support;
 
 use Carbon\Carbon;
+use PHPUnit\Framework\Attributes\Group;
 use YorCreative\Scrubber\Support\LogRecordFactory;
 use YorCreative\Scrubber\Tests\TestCase;
 
+#[Group('LogRecord')]
+#[Group('Unit')]
 class LogRecordFactoryTest extends TestCase
 {
     public function test_it_can_to_array_log_record()

--- a/xdebug.ini
+++ b/xdebug.ini
@@ -1,0 +1,5 @@
+; docker/xdebug.ini
+zend_extension=xdebug.so
+xdebug.mode=coverage
+xdebug.start_with_request=no
+xdebug.discover_client_host=1


### PR DESCRIPTION
### Added
- New `exclude_regex` configuration option for fine-grained control over regex pattern loading
- Support for excluding specific regex patterns when using wildcard loading
- Multiple exclusion formats:
  - Base class names
  - Fully qualified class names
  - RegexCollection constants
  - Custom namespace classes
- Improved documentation for regex pattern exclusion

### Updates
- Updates dockerfile to 8.4 from 8.3
- Adds xdebug for phpunit test coverage
- Updates the attribute\group for the tests.
