### PR TITLE
Fix CI Linter Workflow and Update GitHub Action Versions  

### DIFF
--- a/.github/workflows/fix-php-code-style-issues.yml
+++ b/.github/workflows/fix-php-code-style-issues.yml
@@ -1,6 +1,10 @@
 name: Linter
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   php-code-styling:
@@ -8,14 +12,17 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.head_ref }}
+        uses: actions/checkout@v4
 
-      - name: Fix PHP code style issues
-        uses: aglipanci/laravel-pint-action@latest
-
-      - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v4
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
         with:
-          commit_message: Fix styling
+          php-version: 8.4
+          tools: composer:v2
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-interaction --no-progress
+
+      - name: Run Pint
+        run: vendor/bin/pint --test

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -2,6 +2,8 @@ name: phpunit
 
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 jobs:
@@ -70,7 +72,7 @@ jobs:
         run: sudo apt-get update --fix-missing
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
  ## Summary
  - Update `vendor/bin/pint --test` image
  - Scope push triggers to `main` branch only (prevents redundant runs on tag pushes)
  - Add `pull_request` trigger to linter for pre-merge style checks
  - Upgrade `actions/checkout` to `@v4` across both workflows