### PR TITLE
Improve secret manager provider robustness and consistency

### DIFF
--- a/src/Clients/AwsSecretsManagerClient.php
+++ b/src/Clients/AwsSecretsManagerClient.php
@@ -73,7 +73,12 @@ class AwsSecretsManagerClient
             $secretValue = $result->get('SecretString');
             if ($secretValue === null) {
                 $binaryData = $result->get('SecretBinary');
-                $secretValue = $binaryData !== null ? base64_decode($binaryData) : '';
+                if ($binaryData !== null) {
+                    $decoded = base64_decode($binaryData);
+                    $secretValue = $decoded !== false ? $decoded : '';
+                } else {
+                    $secretValue = '';
+                }
             }
 
             return [

--- a/src/SecretManager/Providers/Vault.php
+++ b/src/SecretManager/Providers/Vault.php
@@ -128,8 +128,12 @@ class Vault implements SecretProviderInterface
         }
     }
 
-    protected static function addSecretsFromData(Collection $collection, string $path, array $data): void
+    protected static function addSecretsFromData(Collection $collection, string $path, array $data, int $depth = 0): void
     {
+        if ($depth >= self::MAX_RECURSION_DEPTH) {
+            return;
+        }
+
         foreach ($data as $key => $value) {
             $secretPath = $path.'.'.$key;
 
@@ -139,7 +143,7 @@ class Vault implements SecretProviderInterface
                 // Include numeric values as strings
                 $collection->push(new Secret($secretPath, (string) $value));
             } elseif (is_array($value)) {
-                self::addSecretsFromData($collection, $secretPath, $value);
+                self::addSecretsFromData($collection, $secretPath, $value, $depth + 1);
             }
             // Skip booleans and null values
         }

--- a/src/SecretManager/SecretManager.php
+++ b/src/SecretManager/SecretManager.php
@@ -8,7 +8,7 @@ use YorCreative\Scrubber\Services\SecretService;
 
 class SecretManager
 {
-    public static function getSecrets($provider): Collection
+    public static function getSecrets(string $provider): Collection
     {
         $providerKey = self::getProviderKey($provider);
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                
  - Handle base64_decode returning false in AWS binary secret handling                                                                                                                                                                                                                      
  - Add recursion depth limit to Vault addSecretsFromData for consistency with Azure and Google providers
  - Add missing string type hint to SecretManager::getSecrets()