### PR TITLE
Fix composer.json typo, update GitHub action versions, use gettype() in error msg

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -15,6 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@v2
+        uses: actions/dependency-review-action@v4

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "framework",
         "scrubber",
         "log scrub",
-        "senstive information scrubber",
+        "sensitive information scrubber",
         "secret scrubber",
         "scrub logs",
         "laravel log scrubber",

--- a/src/Strategies/ContentProcessingStrategy/ContentProcessingStrategy.php
+++ b/src/Strategies/ContentProcessingStrategy/ContentProcessingStrategy.php
@@ -26,7 +26,7 @@ class ContentProcessingStrategy
 
         $handler = $index === null ? null : $this->getHandlers()->get($index);
         if ($handler === null) {
-            throw new RuntimeException('Cannot process content: '.json_encode($content));
+            throw new RuntimeException('Cannot process content of type: '.gettype($content));
         }
 
         return $handler->processContent($content);


### PR DESCRIPTION
## Summary
- Fix typo in composer.json keywords ("senstive" → "sensitive")
- Update dependency-review workflow action versions (checkout@v4, dependency-review-action@v4)
- Use gettype() instead of json_encode() in ContentProcessingStrategy error message